### PR TITLE
feat: Add workflow to force a full cache sync via Pub/Sub.

### DIFF
--- a/.github/workflows/force_sync.yaml
+++ b/.github/workflows/force_sync.yaml
@@ -1,0 +1,37 @@
+name: Force Cache Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to run against'
+        required: true
+        default: 'main'
+        type: choice
+        options:
+        - main
+
+jobs:
+  force-sync:
+    name: Force GCS Cache Sync
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup GCP and dependencies
+      uses: ./.github/actions/setup-gcp-deps
+      with:
+        gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+
+    - name: Publish force sync message
+      run: |
+        CACHE_REFRESH_PUBSUB_TOPIC="${{ env.CACHE_REFRESH_PUBSUB_TOPIC }}"
+        # Create a JSON array of folder IDs from the comma-separated env var.
+        # e.g., "id1,id2" becomes '["id1","id2"]'
+        FOLDER_IDS_JSON='["'$(echo "${GDRIVE_SONG_SHEETS_FOLDER_IDS}" | sed 's/,/","/g')'"]'
+        # Construct the full message payload with force: true
+        MESSAGE_JSON="{\"source_folders\":${FOLDER_IDS_JSON}, \"force\": true}"
+        echo "Publishing message to ${CACHE_REFRESH_PUBSUB_TOPIC}: ${MESSAGE_JSON}"
+        gcloud pubsub topics publish "$CACHE_REFRESH_PUBSUB_TOPIC" --message "${MESSAGE_JSON}"


### PR DESCRIPTION
It's handy to be able to force a full cache sync in case of changes to the sync logic, as the sync normally only operates on changed google docs.