### PR TITLE
feat: Add manifest generation and upload to GCS in workflow

### DIFF
--- a/.github/workflows/generate-songbooks.yaml
+++ b/.github/workflows/generate-songbooks.yaml
@@ -266,3 +266,54 @@ jobs:
       with:
         name: songbook-${{ matrix.edition }}
         path: ukulele-tuesday-songbook-${{ matrix.edition }}.pdf
+
+  publish-manifest:
+    name: Publish Manifest
+    runs-on: ubuntu-latest
+    needs: generate-songbook
+    if: github.ref == 'refs/heads/main'
+    steps:
+    - name: Load environment variables
+      id: load-env
+      uses: falti/dotenv-action@v1.1.4
+      with:
+        path: .env
+        export-variables: true
+        keys-case: bypass
+
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+    - name: Set up Cloud SDK
+      id: setup-sdk
+      run: gcloud config set project ${{ env.GCP_PROJECT_ID }}
+
+    - name: Generate and Upload Manifest
+      id: generate-manifest
+      run: |
+        set -e
+        GCS_LIST_JSON=$(gcloud storage ls "gs://${GCS_SONGBOOKS_BUCKET}/**.pdf" --json)
+        MANIFEST_JSON=$(echo "$GCS_LIST_JSON" | jq -n --argjson files "$GCS_LIST_JSON" --arg bucket "$GCS_SONGBOOKS_BUCKET" '
+        {
+          last_updated_utc: (now | todateiso8601),
+          editions: ($files | map(
+            .name | ltrimstr("gs://\($bucket)/") | capture("ukulele-tuesday-songbook-(?<edition>.*)-(?<date>\\d{4}-\\d{2}-\\d{2})\\.pdf") | .edition as $edition | {
+              key: $edition,
+              value: {
+                url: "https://storage.googleapis.com/\($bucket)/\(.name | ltrimstr("gs://\($bucket)/"))",
+                updated_utc: .updated
+              }
+            }
+          ) | from_entries)
+        }
+        ')
+
+        echo "Generated Manifest:"
+        echo "$MANIFEST_JSON" | jq .
+
+        echo "$MANIFEST_JSON" > manifest.json
+        gcloud storage cp manifest.json "gs://${GCS_SONGBOOKS_BUCKET}/manifest.json" --cache-control="public, max-age=60"
+        echo "✅ Successfully uploaded manifest.json"


### PR DESCRIPTION
Generate manifest.json with metadata on songbook generation, upload it to songbook bucket.