### PR TITLE
refactor: Exclude editions not in order from manifest generation

### DIFF
--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -78,7 +78,6 @@ def generate_manifest(bucket_name: str, new_file_paths: str, editions_order: str
     # Order editions based on the provided order
     ordered_editions = {}
     ordered_edition_keys = editions_order.split()
-    found_keys = set(editions.keys())
 
     for key in ordered_edition_keys:
         if key in editions:


### PR DESCRIPTION
This should remove the hooley songbook from the manifest (and thus from the list of songbooks from the website).