### PR TITLE
Restore hooley + more configuration tweaks for womens book

### DIFF
--- a/generator/config/songbooks.yaml
+++ b/generator/config/songbooks.yaml
@@ -98,7 +98,7 @@
   description: >
     A curated collection of songs by female-identified artists
     for the 2026 women's edition.
-  cover_file_id: null
+  cover_file_id: "1N9eqOVkN4OsCS2yy2A8EVr0YozLn5iAl"
   table_of_contents:
     columns_per_page: 1
     column_width: 360


### PR DESCRIPTION
Configure womens book for single column TOC, add cover from last year as placeholder

Add hooley 2025 back in config