### PR TITLE
Fix womens-2026 songbook cover file format

### DIFF
--- a/generator/config/songbooks.yaml
+++ b/generator/config/songbooks.yaml
@@ -100,7 +100,7 @@
   description: >
     A curated collection of songs by female-identified artists
     for the 2026 women's edition.
-  cover_file_id: "1N9eqOVkN4OsCS2yy2A8EVr0YozLn5iAl"
+  cover_file_id: "1h97bocC-vRFN_OBnHOmK0o01NrzIL8JtZxn_PeQi8bo"
   table_of_contents:
     columns_per_page: 1
     column_width: 360


### PR DESCRIPTION
Replace previous cover file ID with a valid Google Doc. The old file was a DOCX which isn't supported for cover generation. This new file is a proper Google Doc that can be used as the cover template.