### PR TITLE
Fix UI loading errors by switching Material Design Lite CDN

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -39,6 +39,7 @@
                     <li class="mdl-menu__item" data-val="current" data-selected="true">Current</li>
                     <li class="mdl-menu__item" data-val="complete">Complete Collection</li>
                     <li class="mdl-menu__item" data-val="ukulele-hooley-2025">Ukulele Hooley 2025</li>
+                    <li class="mdl-menu__item" data-val="womens-2026">Women's 2026</li>
                   </ul>
                 </div>
                 <details style="margin: 1rem 0;">


### PR DESCRIPTION
- Replace dead code.getmdl.io domain with cdnjs.cloudflare.com
- Remove defer attributes for proper script loading order
- Add guard for componentHandler to prevent ReferenceError
- Fixes 403 errors and cascading JavaScript failures
