### PR TITLE
fix: use songbook-metadata-writer SA in tagupdater to resolve 403 permission errors

### DIFF
--- a/generator/cli/tags.py
+++ b/generator/cli/tags.py
@@ -158,24 +158,14 @@ def update_tags(file_identifier, all, dry_run):
         raise click.Abort()
 
     settings = get_settings()
-    credential_config = settings.google_cloud.credentials.get(
-        "songbook-metadata-writer"
-    )
+    credential_config = settings.google_cloud.credentials.get("tag-updater")
     if not credential_config:
-        click.echo(
-            "Error: credential config 'songbook-metadata-writer' not found.", err=True
-        )
+        click.echo("Error: credential config 'tag-updater' not found.", err=True)
         raise click.Abort()
 
-    # The Tagger needs to read Google Docs content.
-    scopes = list(
-        set(
-            credential_config.scopes
-            + ["https://www.googleapis.com/auth/documents.readonly"]
-        )
+    creds = get_credentials(
+        scopes=credential_config.scopes, target_principal=credential_config.principal
     )
-
-    creds = get_credentials(scopes=scopes, target_principal=credential_config.principal)
     drive_service = build("drive", "v3", credentials=creds)
     docs_service = build("docs", "v1", credentials=creds)
     cache = init_cache()

--- a/generator/common/config.py
+++ b/generator/common/config.py
@@ -146,6 +146,13 @@ class GoogleCloud(BaseModel):
             principal="songbook-metadata-writer@songbook-generator.iam.gserviceaccount.com",
             scopes=["https://www.googleapis.com/auth/drive.metadata"],
         ),
+        "tag-updater": GoogleCloudCredentials(
+            principal="songbook-metadata-writer@songbook-generator.iam.gserviceaccount.com",
+            scopes=[
+                "https://www.googleapis.com/auth/drive.metadata",
+                "https://www.googleapis.com/auth/documents.readonly",
+            ],
+        ),
         "songbook-cache-updater": GoogleCloudCredentials(
             principal="songbook-generator@songbook-generator.iam.gserviceaccount.com",
             scopes=["https://www.googleapis.com/auth/drive.readonly"],

--- a/generator/tagupdater/main.py
+++ b/generator/tagupdater/main.py
@@ -38,11 +38,9 @@ def _get_services():
             os.environ["GOOGLE_CLOUD_PROJECT"] = project_id
 
     # Get credentials for tagging (needs drive write permissions)
-    tagger_credential_config = settings.google_cloud.credentials.get(
-        "songbook-generator"
-    )
+    tagger_credential_config = settings.google_cloud.credentials.get("tag-updater")
     if not tagger_credential_config:
-        raise click.Abort("Credential config 'songbook-generator' not found.")
+        raise click.Abort("Credential config 'tag-updater' not found.")
 
     tagger_creds = get_credentials(
         scopes=tagger_credential_config.scopes,

--- a/generator/tagupdater/test_main.py
+++ b/generator/tagupdater/test_main.py
@@ -297,9 +297,7 @@ def test_get_services_success(
     result = _get_services()
 
     # Verify credentials config lookup used correct key
-    mock_settings.google_cloud.credentials.get.assert_called_once_with(
-        "songbook-generator"
-    )
+    mock_settings.google_cloud.credentials.get.assert_called_once_with("tag-updater")
 
     # Verify get_credentials was called correctly
     mock_get_credentials.assert_called_once_with(
@@ -353,9 +351,7 @@ def test_get_services_missing_credential_config(
         _get_services()
 
     # Verify the correct credential config was requested
-    mock_settings.google_cloud.credentials.get.assert_called_once_with(
-        "songbook-generator"
-    )
+    mock_settings.google_cloud.credentials.get.assert_called_once_with("tag-updater")
 
 
 @patch("generator.tagupdater.main.Tagger")


### PR DESCRIPTION

The tagupdater was using the 'songbook-generator' credential config, whose service account (songbook-generator@...) lacks Drive file-level write permissions on song sheets. This caused all files().update() calls to fail with 403 "insufficientFilePermissions".

Adds a dedicated 'tag-updater' credential config using the songbook-metadata-writer SA (which has the correct Drive write access) with drive.metadata and documents.readonly scopes, mirroring the setup used by the CLI's 'tags update' command. The regression was introduced in ff8cfb3.

Fixes #278.