### PR TITLE
Cache updater: prime GCS cache for a specific edition's songs

### DIFF
--- a/.github/workflows/trigger_sync.yaml
+++ b/.github/workflows/trigger_sync.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         default: false
         type: boolean
+      edition_folder_id:
+        description: 'Drive folder ID of the edition to prime cache for (syncs its Songs/ subfolder)'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   trigger-sync:
@@ -42,4 +47,5 @@ jobs:
         gcloud pubsub topics publish "$CACHE_REFRESH_PUBSUB_TOPIC" \
           --message="Triggering cache sync and merge" \
           --attribute="force=${{ github.event.inputs.force }}" \
-          --attribute="rebuild_only=${{ github.event.inputs.rebuild_only }}"
+          --attribute="rebuild_only=${{ github.event.inputs.rebuild_only }}" \
+          --attribute="edition_folder_id=${{ github.event.inputs.edition_folder_id }}"

--- a/generator/cache_updater/main.py
+++ b/generator/cache_updater/main.py
@@ -233,10 +233,13 @@ def _parse_cloud_event(cloud_event: CloudEvent) -> dict:
     # Attributes are strings ('true' / 'false').
     force_sync = attributes.get("force", "false").lower() == "true"
     rebuild_only = attributes.get("rebuild_only", "false").lower() == "true"
+    # Normalise empty string (GitHub Actions default) to None.
+    edition_folder_id = attributes.get("edition_folder_id") or None
 
     return {
         "force_sync": force_sync,
         "rebuild_only": rebuild_only,
+        "edition_folder_id": edition_folder_id,
     }
 
 
@@ -256,9 +259,11 @@ def cache_updater_main(cloud_event: CloudEvent):
             event_params = _parse_cloud_event(cloud_event)
             force_sync = event_params["force_sync"]
             rebuild_only = event_params["rebuild_only"]
+            edition_folder_id = event_params["edition_folder_id"]
 
             main_span.set_attribute("force_sync", str(force_sync))
             main_span.set_attribute("rebuild_only", str(rebuild_only))
+            main_span.set_attribute("edition_folder_id", edition_folder_id or "")
 
             if rebuild_only:
                 # Skip Drive sync entirely — just rebuild the merged PDF from
@@ -299,12 +304,27 @@ def cache_updater_main(cloud_event: CloudEvent):
                     sync_span.set_attribute("synced_files_count", synced_files_count)
                     click.echo("Sync complete.")
 
-                if not force_sync and synced_files_count == 0:
+                if not force_sync and synced_files_count == 0 and not edition_folder_id:
                     click.echo(
                         "No files were updated since the last merge. Nothing to do."
                     )
                     main_span.set_attribute("status", "skipped_no_changes")
                     return
+
+            if edition_folder_id:
+                click.echo(
+                    f"edition_folder_id set. Syncing edition from folder: {edition_folder_id}"
+                )
+                with services["tracer"].start_as_current_span(
+                    "edition_sync_operation"
+                ) as esync_span:
+                    edition_synced = sync.sync_cache_for_edition_folder(
+                        edition_folder_id, services
+                    )
+                    esync_span.set_attribute("edition_synced_count", edition_synced)
+                    click.echo(
+                        f"Edition sync complete. {edition_synced} file(s) synced."
+                    )
 
             click.echo("Starting PDF merge operation")
 

--- a/generator/cache_updater/sync.py
+++ b/generator/cache_updater/sync.py
@@ -8,6 +8,8 @@ from ..common.caching import init_cache
 from ..common.gdrive import GoogleDriveClient
 from ..worker.models import File
 
+_SONGS_SUBFOLDER_NAME = "Songs"
+
 
 def _sync_gcs_metadata_from_drive(
     source_folders: List[str], cache, drive_service, cache_bucket, tracer
@@ -166,3 +168,121 @@ def download_gcs_cache_to_local(
                 local_cache.put_metadata(blob.name, blob.metadata)
 
         click.echo("Download complete.")
+
+
+def _sync_gcs_metadata_for_files(files: List[File], cache_bucket, tracer):
+    """
+    Update GCS blob metadata for a specific list of File objects.
+
+    Unlike _sync_gcs_metadata_from_drive, no Drive query is performed;
+    the caller supplies the File objects directly. Does a targeted
+    blob.reload() per file ID rather than listing all blobs.
+    """
+    with tracer.start_as_current_span("_sync_gcs_metadata_for_files") as span:
+        click.echo("Syncing GCS metadata for edition files...")
+        file_map = {f.id: f for f in files}
+        span.set_attribute("files_count", len(file_map))
+
+        prefix = "song-sheets/"
+        updated_count, skipped_count, error_count = 0, 0, 0
+
+        for file_id, drive_file in file_map.items():
+            blob_name = f"{prefix}{file_id}.pdf"
+            blob = cache_bucket.blob(blob_name)
+            try:
+                blob.reload()
+            except gcp_exceptions.NotFound:
+                skipped_count += 1
+                continue
+
+            expected_name = drive_file.name
+            current_metadata = blob.metadata or {}
+            if current_metadata.get(
+                "gdrive-file-id"
+            ) == file_id and current_metadata.get("gdrive-file-name") == str(
+                expected_name
+            ):
+                continue
+
+            new_metadata = dict(current_metadata)
+            new_metadata["gdrive-file-id"] = file_id
+            new_metadata["gdrive-file-name"] = expected_name
+            try:
+                blob.metadata = new_metadata
+                blob.patch()
+                click.echo(f"  UPDATE: {blob_name} metadata updated.")
+                updated_count += 1
+            except gcp_exceptions.GoogleAPICallError as e:
+                click.echo(f"  ERROR: Failed to update {blob_name}: {e}", err=True)
+                error_count += 1
+
+        click.echo(
+            f"Edition metadata sync: {updated_count} updated, "
+            f"{skipped_count} skipped, {error_count} errors."
+        )
+        span.set_attribute("updated_count", updated_count)
+        span.set_attribute("skipped_count", skipped_count)
+        span.set_attribute("error_count", error_count)
+
+
+def sync_cache_for_edition_folder(edition_folder_id: str, services) -> int:
+    """
+    Prime the GCS cache with all songs from an edition's Songs/ subfolder.
+
+    Resolves shortcuts so that shortcut entries pointing at source-folder
+    files are stored under the *real* file ID — matching the key that
+    copy_pdfs looks up in the merged PDF index.
+
+    Returns:
+        Number of files synced.  0 if the Songs/ subfolder is missing or empty.
+    """
+    with services["tracer"].start_as_current_span(
+        "sync_cache_for_edition_folder"
+    ) as span:
+        span.set_attribute("edition_folder_id", edition_folder_id)
+
+        cache = init_cache()
+        gdrive_client = GoogleDriveClient(cache=cache, drive=services["drive"])
+
+        songs_folder_id = gdrive_client.find_subfolder_by_name(
+            edition_folder_id, _SONGS_SUBFOLDER_NAME
+        )
+        if not songs_folder_id:
+            click.echo(
+                f"Warning: No '{_SONGS_SUBFOLDER_NAME}' subfolder found in edition "
+                f"folder {edition_folder_id}. Nothing to sync.",
+                err=True,
+            )
+            span.set_attribute("songs_subfolder_found", False)
+            return 0
+
+        span.set_attribute("songs_subfolder_found", True)
+        span.set_attribute("songs_folder_id", songs_folder_id)
+
+        files = gdrive_client.list_folder_contents(
+            songs_folder_id, resolve_shortcuts=True
+        )
+        span.set_attribute("files_found", len(files))
+
+        if not files:
+            click.echo(
+                f"Warning: '{_SONGS_SUBFOLDER_NAME}' subfolder {songs_folder_id} "
+                "is empty. Nothing to sync."
+            )
+            return 0
+
+        click.echo(
+            f"Syncing {len(files)} file(s) from edition "
+            f"'{_SONGS_SUBFOLDER_NAME}/' subfolder..."
+        )
+        for file in files:
+            with services["tracer"].start_as_current_span("sync_edition_file"):
+                click.echo(f"  Syncing {file.name} (ID: {file.id})")
+                gdrive_client.download_file_stream(file, use_cache=True)
+
+        _sync_gcs_metadata_for_files(
+            files, services["cache_bucket"], services["tracer"]
+        )
+
+        span.set_attribute("synced_count", len(files))
+        return len(files)

--- a/generator/cli/cache.py
+++ b/generator/cli/cache.py
@@ -57,6 +57,11 @@ def cache():
     default=False,
     help="Sync to the local cache instead of GCS.",
 )
+@click.option(
+    "--edition-folder",
+    default=None,
+    help="Drive folder ID of the edition to prime cache for (syncs its Songs/ subfolder).",
+)
 def sync_cache_command(
     ctx,
     source_folder,
@@ -65,6 +70,7 @@ def sync_cache_command(
     update_tags_only,
     update_tags,
     local,
+    edition_folder,
     **kwargs,
 ):
     """Sync files and metadata from Google Drive to the cache."""
@@ -117,6 +123,13 @@ def sync_cache_command(
             modified_after=last_merge_time,
         )
         click.echo("Cache synchronization complete.")
+
+        if edition_folder:
+            click.echo(f"Syncing edition cache for folder: {edition_folder}")
+            from ..cache_updater.sync import sync_cache_for_edition_folder
+
+            edition_synced = sync_cache_for_edition_folder(edition_folder, services)
+            click.echo(f"Edition sync complete. {edition_synced} file(s) synced.")
 
     except click.Abort:
         # click.Abort is raised on purpose, so just re-raise.


### PR DESCRIPTION
Adds edition_folder_id support so the cache updater can download all
songs from a drive edition's Songs/ subfolder (resolving shortcuts to
their real file IDs) into the GCS individual-blob cache, then rebuild
the merged PDF.

Primary use-case: trigger_sync.yaml with rebuild_only=true and
edition_folder_id=<folder> to unblock generation for an edition whose
songs are not yet cached, without paying the cost of a full Drive sync.

- sync.py: add sync_cache_for_edition_folder() and the helper
  _sync_gcs_metadata_for_files() (targeted per-blob metadata update)
- main.py: parse edition_folder_id attribute; call edition sync before
  the merge step; guard the no-changes early-return so it doesn't fire
  when an edition sync was requested
- trigger_sync.yaml: expose edition_folder_id as a workflow_dispatch input
- cli/cache.py: add --edition-folder option to cache sync command

https://claude.ai/code/session_01TNGJJS737piznNeHnmweQC