### PR TITLE
fix: combine pubsub attributes into single --attribute flag

### DIFF
--- a/.github/workflows/trigger_sync.yaml
+++ b/.github/workflows/trigger_sync.yaml
@@ -46,6 +46,4 @@ jobs:
         echo "Publishing sync message to ${CACHE_REFRESH_PUBSUB_TOPIC} with force=${{ github.event.inputs.force }}"
         gcloud pubsub topics publish "$CACHE_REFRESH_PUBSUB_TOPIC" \
           --message="Triggering cache sync and merge" \
-          --attribute="force=${{ github.event.inputs.force }}" \
-          --attribute="rebuild_only=${{ github.event.inputs.rebuild_only }}" \
-          --attribute="edition_folder_id=${{ github.event.inputs.edition_folder_id }}"
+          --attribute="force=${{ github.event.inputs.force }},rebuild_only=${{ github.event.inputs.rebuild_only }},edition_folder_id=${{ github.event.inputs.edition_folder_id }}"


### PR DESCRIPTION
gcloud pubsub topics publish only honours the last --attribute flag when multiple are passed; force and rebuild_only were silently dropped, so rebuild_only=true had no effect.