### PR TITLE
fix: use edition.id from manifest for output filenames

### DIFF
--- a/.github/workflows/generate-songbook.yaml
+++ b/.github/workflows/generate-songbook.yaml
@@ -173,12 +173,12 @@ jobs:
           --manifest "${{ env.OUTPUT_MANIFEST }}" \
           --verbose
 
-        echo "✅ PDF validation passed for ${{ inputs.edition }} edition"
+        echo "✅ PDF validation passed for ${{ steps.set-output-names.outputs.effective_edition }} edition"
 
     - name: Upload Songbook Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: songbook-artifact-${{ inputs.edition }}
+        name: songbook-artifact-${{ steps.set-output-names.outputs.effective_edition }}
         path: |
           ${{ env.OUTPUT_PDF }}
           ${{ env.OUTPUT_MANIFEST }}
@@ -217,7 +217,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: ./songbooks
-        name: songbook-artifact-${{ inputs.edition }}
+        name: songbook-artifact-${{ needs.generate-songbook.outputs.effective_edition }}
 
     - name: Upload PDF to GCS
       id: upload-pdf


### PR DESCRIPTION
When generating a Drive-based edition, the raw Drive folder ID was used in the output PDF filename and GCS publish path. Now the workflow reads edition.id from the generated manifest (set in the .songbook.yaml) to produce a human-friendly name like spring-2026 instead.