### PR TITLE
feat: add language as an LLM-enriched tag

### DIFF
--- a/generator/tagupdater/tags.py
+++ b/generator/tagupdater/tags.py
@@ -657,3 +657,18 @@ def genre(ctx: Context, raw: Optional[str], *, max_genres: int = 3) -> Optional[
         return None
     parts = [g.strip().lower() for g in raw.split(",") if g.strip()][:max_genres]
     return ",".join(parts) if parts else None
+
+
+@llm_tag(
+    prompt=(
+        'What language is "{song}" by {artist} performed in? '
+        'Reply with only the language name in lowercase (e.g. "english", "irish", "french"), '
+        "or null if unknown."
+    ),
+    only_if_unset=True,
+)
+def language(ctx: Context, raw: Optional[str]) -> Optional[str]:
+    """Looks up the language the song is performed in via Gemini + Google Search."""
+    if not raw:
+        return None
+    return raw.strip().lower() or None


### PR DESCRIPTION
Adds a new `language` tag that uses Gemini to identify the language a
song is performed in (e.g. "english", "irish", "french"). Follows the
same pattern as year/duration/genre with only_if_unset=True and
lowercase normalisation.

https://claude.ai/code/session_01GUEbMxvnze2NLUAb9SV5Kg