### PR TITLE
fix: deploy worker on songbook config changes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'generator/config/songbooks/**'
   pull_request:
     branches:
       - main
@@ -14,8 +12,6 @@ on:
       - reopened
       - synchronize
       - closed
-    paths-ignore:
-      - 'generator/config/songbooks/**'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Config files are bundled into the worker at deploy time, so config-only changes must trigger a redeploy. Removes paths-ignore exclusion that was silently skipping redeployment on these changes.

Closes #353 (partial — PR-specific worker for preview generation is tracked separately)