### PR TITLE
Increase songbook generation workflow timeout to 200 seconds

### DIFF
--- a/.github/workflows/generate-songbook.yaml
+++ b/.github/workflows/generate-songbook.yaml
@@ -72,7 +72,7 @@ jobs:
         fi
         echo "Created job with ID: $JOB_ID"
 
-        TIMEOUT=120
+        TIMEOUT=200
         ELAPSED=0
         POLL_INTERVAL=1
         SOURCE_GCS_PATH=""


### PR DESCRIPTION
Give the worker more time to complete PDF generation before timing out. This accommodates slower runs with individual song downloads.