### PR TITLE
Add ChordPro song export support

### DIFF
--- a/generator/cli/__init__.py
+++ b/generator/cli/__init__.py
@@ -8,6 +8,7 @@ import logging
 import click
 
 from .cache import cache
+from .chordpro import generate_chordpro
 from .editions import editions
 from .generate import generate
 from .misc import print_settings, validate_pdf_cli
@@ -32,6 +33,7 @@ def cli(ctx, log_level: str):
 
 cli.add_command(generate)
 cli.add_command(generate_pptx)
+cli.add_command(generate_chordpro)
 cli.add_command(songs)
 cli.add_command(cache)
 cli.add_command(print_settings)

--- a/generator/cli/chordpro.py
+++ b/generator/cli/chordpro.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import click
+
+from ..common.config import get_settings
+from ..common.gdrive import GoogleDriveClient
+from ..worker.chordpro import generate_song_chordpro
+from ..worker.pdf import init_services
+from .utils import _resolve_file_id, global_options
+
+
+def _slugify(name: str) -> str:
+    """Convert a file name like 'Love Me Do' to 'Love_Me_Do.cho'."""
+    return name + ".cho"
+
+
+@click.command("generate-chordpro")
+@global_options
+@click.pass_context
+@click.argument("song_identifier")
+@click.option(
+    "--destination-path",
+    "-d",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Where to save the generated ChordPro file (default: out/<song-name>.cho)",
+)
+@click.option(
+    "--no-annotations",
+    is_flag=True,
+    help="Strip all annotations (stage directions, performer markers)",
+)
+@click.option(
+    "--detect-sections",
+    is_flag=True,
+    help="Attempt to auto-detect verse/chorus/bridge sections",
+)
+def generate_chordpro(
+    ctx,
+    song_identifier: str,
+    destination_path: Path | None,
+    no_annotations: bool,
+    detect_sections: bool,
+    **kwargs,
+):
+    """Generate a ChordPro file for a song from its Google Drive document."""
+    settings = get_settings()
+    credential_config = settings.google_cloud.credentials.get("songbook-generator")
+    if not credential_config:
+        click.echo("Error: credential config 'songbook-generator' not found.", err=True)
+        raise click.Abort()
+
+    drive, cache = init_services(
+        scopes=credential_config.scopes,
+        target_principal=credential_config.principal,
+    )
+    gdrive_client = GoogleDriveClient(cache=cache, drive=drive)
+
+    file_id = _resolve_file_id(gdrive_client, song_identifier)
+
+    files_meta = gdrive_client.get_files_metadata_by_ids([file_id])
+    if not files_meta:
+        click.echo(f"Error: could not fetch metadata for file ID {file_id}.", err=True)
+        raise click.Abort()
+    file_name = files_meta[0].name
+
+    if destination_path is None:
+        destination_path = Path("out") / _slugify(file_name)
+
+    click.echo(f"Generating ChordPro for: {file_name}")
+    generate_song_chordpro(
+        gdrive_client,
+        file_id,
+        file_name,
+        destination_path,
+        include_annotations=not no_annotations,
+        detect_sections=detect_sections,
+    )
+    click.echo(f"Saved to: {destination_path}")

--- a/generator/cli/chordpro.py
+++ b/generator/cli/chordpro.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
 import click
+from googleapiclient.discovery import build
 
+from ..common.caching import init_cache
 from ..common.config import get_settings
 from ..common.gdrive import GoogleDriveClient
 from ..worker.chordpro import generate_song_chordpro
-from ..worker.pdf import init_services
+from ..worker.gcp import get_credentials
 from .utils import _resolve_file_id, global_options
 
 
@@ -50,11 +52,14 @@ def generate_chordpro(
         click.echo("Error: credential config 'songbook-generator' not found.", err=True)
         raise click.Abort()
 
-    drive, cache = init_services(
+    creds = get_credentials(
         scopes=credential_config.scopes,
         target_principal=credential_config.principal,
     )
-    gdrive_client = GoogleDriveClient(cache=cache, drive=drive)
+    drive_service = build("drive", "v3", credentials=creds)
+    docs_service = build("docs", "v1", credentials=creds)
+    cache = init_cache()
+    gdrive_client = GoogleDriveClient(cache=cache, drive=drive_service)
 
     file_id = _resolve_file_id(gdrive_client, song_identifier)
 
@@ -69,7 +74,7 @@ def generate_chordpro(
 
     click.echo(f"Generating ChordPro for: {file_name}")
     generate_song_chordpro(
-        gdrive_client,
+        docs_service,
         file_id,
         file_name,
         destination_path,

--- a/generator/worker/chordpro.py
+++ b/generator/worker/chordpro.py
@@ -1,19 +1,32 @@
 import re
 from pathlib import Path
 
-from ..common.gdrive import GoogleDriveClient
-from .pptx import parse_doc_text
-
 _METADATA_RE = re.compile(r"\bbpm\b|\b\d+/\d+\b", re.IGNORECASE)
 _CHORD_PATTERN = re.compile(r"\(([^)]+)\)")
 _ANNOTATION_PATTERN = re.compile(r"\s*\[.*?\]")
+
+
+def _para_plain_text(para: dict) -> str:
+    return "".join(
+        run["textRun"].get("content", "")
+        for run in para.get("elements", [])
+        if "textRun" in run
+    )
+
+
+def _is_bold(run: dict) -> bool:
+    return run.get("textRun", {}).get("textStyle", {}).get("bold", False)
+
+
+def _is_italic(run: dict) -> bool:
+    return run.get("textRun", {}).get("textStyle", {}).get("italic", False)
 
 
 def parse_metadata(text: str) -> dict:
     """Extract BPM and time signature from song text."""
     metadata = {"tempo": None, "time_sig": None}
 
-    lines = text.split("\n")[:5]  # Check first few lines
+    lines = text.split("\n")[:5]
     for line in lines:
         bpm_match = re.search(r"\b(\d+)\s*bpm\b", line, re.IGNORECASE)
         if bpm_match:
@@ -24,6 +37,17 @@ def parse_metadata(text: str) -> dict:
             metadata["time_sig"] = time_match.group(1)
 
     return metadata
+
+
+def parse_metadata_from_json(doc_json: dict) -> dict:
+    """Extract BPM and time signature from a Docs API document."""
+    for element in doc_json.get("body", {}).get("content", []):
+        if "paragraph" not in element:
+            continue
+        text = _para_plain_text(element["paragraph"])
+        if _METADATA_RE.search(text):
+            return parse_metadata(text)
+    return {"tempo": None, "time_sig": None}
 
 
 def cells_per_bar(time_sig: str) -> int:
@@ -80,6 +104,86 @@ def strip_annotations(text: str) -> str | None:
     return result if result else None
 
 
+def parse_doc_json(
+    doc_json: dict,
+    include_annotations: bool = True,
+    time_sig: str = "4/4",
+) -> tuple[str, list[str]]:
+    """Parse a Google Docs API JSON document into (title, ChordPro-formatted sections).
+
+    Uses text run formatting to distinguish chords (bold) from annotations (italic)
+    and lyrics (regular), avoiding the ambiguity of plain-text heuristics.
+    """
+    content = doc_json.get("body", {}).get("content", [])
+    paragraphs = [el["paragraph"] for el in content if "paragraph" in el]
+
+    if not paragraphs:
+        return "Untitled", []
+
+    title_line = _para_plain_text(paragraphs[0]).strip()
+    title = title_line.split(" - ")[0].strip() or "Untitled"
+
+    sections: list[str] = []
+    current_lines: list[str] = []
+
+    for para in paragraphs[1:]:
+        plain = _para_plain_text(para).strip()
+
+        if _METADATA_RE.search(plain):
+            continue
+
+        if not plain:
+            if current_lines:
+                sections.append("\n".join(current_lines))
+                current_lines = []
+            continue
+
+        runs = [el for el in para.get("elements", []) if "textRun" in el]
+        content_runs = [r for r in runs if r["textRun"].get("content", "").strip()]
+
+        # All bold → chord-only paragraph → grid
+        if content_runs and all(_is_bold(r) for r in content_runs):
+            chords = _CHORD_PATTERN.findall(plain)
+            if chords:
+                grid = format_as_grid(chords, time_sig)
+                current_lines.append("{start_of_grid}")
+                current_lines.extend(grid.split("\n"))
+                current_lines.append("{end_of_grid}")
+                continue
+
+        # All italic → standalone annotation paragraph
+        if content_runs and all(_is_italic(r) for r in content_runs):
+            if include_annotations:
+                annotation_text = plain.strip("[]() \t")
+                current_lines.append(f"{{comment: {annotation_text}}}")
+            continue
+
+        # Mixed paragraph: process run by run
+        line_parts = []
+        for run in runs:
+            text_run = run["textRun"]
+            run_content = text_run.get("content", "").rstrip("\n")
+            if not run_content:
+                continue
+            style = text_run.get("textStyle", {})
+
+            if style.get("bold"):
+                line_parts.append(convert_chords_to_chordpro(run_content))
+            elif style.get("italic"):
+                pass  # inline annotations don't map cleanly to ChordPro
+            else:
+                line_parts.append(run_content)
+
+        line = "".join(line_parts).strip()
+        if line:
+            current_lines.append(line)
+
+    if current_lines:
+        sections.append("\n".join(current_lines))
+
+    return title, sections
+
+
 def build_chordpro(
     title: str,
     artist: str,
@@ -88,7 +192,7 @@ def build_chordpro(
     include_annotations: bool = True,
     detect_sections: bool = False,
 ) -> str:
-    """Build a complete ChordPro file from song components."""
+    """Assemble a ChordPro file from pre-formatted sections."""
     lines = []
 
     lines.append(f"{{title: {title}}}")
@@ -103,56 +207,15 @@ def build_chordpro(
     lines.append("")
 
     for section in sections:
-        if not section.strip():
+        if section.strip():
+            lines.append(section)
             lines.append("")
-            continue
-
-        section_lines = section.split("\n")
-        for line in section_lines:
-            if not line.strip():
-                lines.append("")
-                continue
-
-            is_chord_only, chords = detect_chord_only_line(line)
-
-            if is_chord_only:
-                time_sig = metadata.get("time_sig", "4/4")
-                grid = format_as_grid(chords, time_sig)
-                lines.append("{start_of_grid}")
-                lines.extend(grid.split("\n"))
-                lines.append("{end_of_grid}")
-            else:
-                if not include_annotations:
-                    stripped = strip_annotations(line)
-                    if stripped is None:
-                        continue
-                    processed_line = convert_chords_to_chordpro(stripped)
-                else:
-                    annotation_match = re.match(r"^(\[.*?\])\s*(.*)", line)
-                    if annotation_match:
-                        annotation, rest = annotation_match.groups()
-                        annotation_text = annotation[1:-1]
-                        if rest:
-                            processed_line = (
-                                f"{{comment: {annotation_text}}}\n"
-                                f"{convert_chords_to_chordpro(rest)}"
-                            )
-                        else:
-                            processed_line = f"{{comment: {annotation_text}}}"
-                    else:
-                        processed_line = convert_chords_to_chordpro(line)
-
-                for processed in processed_line.split("\n"):
-                    if processed.strip():
-                        lines.append(processed)
-
-        lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"
 
 
 def generate_song_chordpro(
-    gdrive_client: GoogleDriveClient,
+    docs_service,
     file_id: str,
     file_name: str,
     destination_path: Path,
@@ -160,18 +223,16 @@ def generate_song_chordpro(
     detect_sections: bool = False,
 ) -> None:
     """Generate a ChordPro file from a Google Drive song document."""
-    raw = gdrive_client.download_file(
-        file_id=file_id,
-        file_name=file_name,
-        cache_prefix="song-chordpro",
-        mime_type="text/plain",
-        export=True,
-        use_cache=False,
-    )
-    text = raw.decode("utf-8")
+    doc_json = docs_service.documents().get(documentId=file_id).execute()
 
-    title, sections = parse_doc_text(text, include_annotations=include_annotations)
-    metadata = parse_metadata(text)
+    metadata = parse_metadata_from_json(doc_json)
+    time_sig = metadata.get("time_sig") or "4/4"
+
+    title, sections = parse_doc_json(
+        doc_json,
+        include_annotations=include_annotations,
+        time_sig=time_sig,
+    )
 
     artist = ""
     if " - " in file_name:
@@ -182,8 +243,6 @@ def generate_song_chordpro(
         artist,
         sections,
         metadata,
-        include_annotations=include_annotations,
-        detect_sections=detect_sections,
     )
 
     destination_path.parent.mkdir(parents=True, exist_ok=True)

--- a/generator/worker/chordpro.py
+++ b/generator/worker/chordpro.py
@@ -104,17 +104,25 @@ def strip_annotations(text: str) -> str | None:
     return result if result else None
 
 
-def _parse_chord_bars(text: str) -> list[list[str]]:
+def _parse_chord_bars(text: str, time_sig: str = "4/4") -> list[list[str]]:
     """Split chord-only text into bars using whitespace as bar boundaries.
 
-    '(C) (G)' → two bars [['C'], ['G']]
-    '(X)(X)(X)(X)' → one bar [['X', 'X', 'X', 'X']]
-    '(C) (X)(X)(X)(X) (F)' → three bars [['C'], ['X','X','X','X'], ['F']]
+    A single chord per token is padded with dots to fill the bar (per ChordPro spec,
+    cells determine duration; '.' = sustain/empty beat).
+
+    '(C) (G)' in 4/4 → [['C','.','.','.''], ['G','.','.','.']]
+    '(X)(X)(X)(X)' in 4/4 → [['X','X','X','X']]
+    '(C) (X)(X)(X)(X) (F)' in 4/4 → [['C','.','.','.''], ['X','X','X','X'], ['F','.','.','.']]
     """
+    cpb = cells_per_bar(time_sig)
     bars = []
     for token in text.strip().split():
         chords = _CHORD_PATTERN.findall(token)
-        if chords:
+        if not chords:
+            continue
+        if len(chords) == 1:
+            bars.append(chords + ["."] * (cpb - 1))
+        else:
             bars.append(chords)
     return bars
 
@@ -159,7 +167,7 @@ def parse_doc_json(
         # All bold → chord-only paragraph → grid
         # Space between chord groups = bar boundary; no space = beats within same bar
         if content_runs and all(_is_bold(r) for r in content_runs):
-            bars = _parse_chord_bars(plain)
+            bars = _parse_chord_bars(plain, time_sig)
             if bars:
                 grid_line = "| " + " | ".join(" ".join(bar) for bar in bars) + " |"
                 current_lines.append("{start_of_grid}")

--- a/generator/worker/chordpro.py
+++ b/generator/worker/chordpro.py
@@ -1,4 +1,3 @@
-import math
 import re
 from pathlib import Path
 
@@ -161,7 +160,15 @@ def generate_song_chordpro(
     detect_sections: bool = False,
 ) -> None:
     """Generate a ChordPro file from a Google Drive song document."""
-    text = gdrive_client.export_file_as_text(file_id, cache_prefix="song-chordpro")
+    raw = gdrive_client.download_file(
+        file_id=file_id,
+        file_name=file_name,
+        cache_prefix="song-chordpro",
+        mime_type="text/plain",
+        export=True,
+        use_cache=False,
+    )
+    text = raw.decode("utf-8")
 
     title, sections = parse_doc_text(text, include_annotations=include_annotations)
     metadata = parse_metadata(text)

--- a/generator/worker/chordpro.py
+++ b/generator/worker/chordpro.py
@@ -1,0 +1,183 @@
+import math
+import re
+from pathlib import Path
+
+from ..common.gdrive import GoogleDriveClient
+from .pptx import parse_doc_text
+
+_METADATA_RE = re.compile(r"\bbpm\b|\b\d+/\d+\b", re.IGNORECASE)
+_CHORD_PATTERN = re.compile(r"\(([^)]+)\)")
+_ANNOTATION_PATTERN = re.compile(r"\s*\[.*?\]")
+
+
+def parse_metadata(text: str) -> dict:
+    """Extract BPM and time signature from song text."""
+    metadata = {"tempo": None, "time_sig": None}
+
+    lines = text.split("\n")[:5]  # Check first few lines
+    for line in lines:
+        bpm_match = re.search(r"\b(\d+)\s*bpm\b", line, re.IGNORECASE)
+        if bpm_match:
+            metadata["tempo"] = int(bpm_match.group(1))
+
+        time_match = re.search(r"\b(\d+/\d+)\b", line)
+        if time_match:
+            metadata["time_sig"] = time_match.group(1)
+
+    return metadata
+
+
+def cells_per_bar(time_sig: str) -> int:
+    """Get number of cells per bar for a time signature."""
+    if not time_sig:
+        return 4
+
+    try:
+        numerator = int(time_sig.split("/")[0])
+        return numerator
+    except (ValueError, IndexError):
+        return 4
+
+
+def detect_chord_only_line(line: str) -> tuple[bool, list[str]]:
+    """Check if a line contains only chords (no lyrics)."""
+    chords = _CHORD_PATTERN.findall(line)
+    if not chords:
+        return False, []
+
+    line_without_chords = _CHORD_PATTERN.sub("", line).strip()
+    is_chord_only = len(line_without_chords) == 0 or line_without_chords.isspace()
+
+    return is_chord_only, chords
+
+
+def format_as_grid(chords: list[str], time_sig: str) -> str:
+    """Format chord list as ChordPro grid."""
+    if not chords:
+        return ""
+
+    cells = cells_per_bar(time_sig)
+    grid_lines = []
+
+    for i in range(0, len(chords), cells):
+        bar_chords = chords[i : i + cells]
+        while len(bar_chords) < cells:
+            bar_chords.append(".")
+
+        bar = " ".join(bar_chords)
+        grid_lines.append(f"| {bar} |")
+
+    return "\n".join(grid_lines)
+
+
+def convert_chords_to_chordpro(text: str) -> str:
+    """Convert chord notation from (chord) to [chord]."""
+    return _CHORD_PATTERN.sub(r"[\1]", text)
+
+
+def strip_annotations(text: str) -> str | None:
+    """Remove annotations from text, return None if line becomes empty."""
+    result = _ANNOTATION_PATTERN.sub("", text).strip()
+    return result if result else None
+
+
+def build_chordpro(
+    title: str,
+    artist: str,
+    sections: list[str],
+    metadata: dict,
+    include_annotations: bool = True,
+    detect_sections: bool = False,
+) -> str:
+    """Build a complete ChordPro file from song components."""
+    lines = []
+
+    lines.append(f"{{title: {title}}}")
+    if artist:
+        lines.append(f"{{artist: {artist}}}")
+
+    if metadata.get("tempo"):
+        lines.append(f"{{tempo: {metadata['tempo']}}}")
+    if metadata.get("time_sig"):
+        lines.append(f"{{time: {metadata['time_sig']}}}")
+
+    lines.append("")
+
+    for section in sections:
+        if not section.strip():
+            lines.append("")
+            continue
+
+        section_lines = section.split("\n")
+        for line in section_lines:
+            if not line.strip():
+                lines.append("")
+                continue
+
+            is_chord_only, chords = detect_chord_only_line(line)
+
+            if is_chord_only:
+                time_sig = metadata.get("time_sig", "4/4")
+                grid = format_as_grid(chords, time_sig)
+                lines.append("{start_of_grid}")
+                lines.extend(grid.split("\n"))
+                lines.append("{end_of_grid}")
+            else:
+                if not include_annotations:
+                    stripped = strip_annotations(line)
+                    if stripped is None:
+                        continue
+                    processed_line = convert_chords_to_chordpro(stripped)
+                else:
+                    annotation_match = re.match(r"^(\[.*?\])\s*(.*)", line)
+                    if annotation_match:
+                        annotation, rest = annotation_match.groups()
+                        annotation_text = annotation[1:-1]
+                        if rest:
+                            processed_line = (
+                                f"{{comment: {annotation_text}}}\n"
+                                f"{convert_chords_to_chordpro(rest)}"
+                            )
+                        else:
+                            processed_line = f"{{comment: {annotation_text}}}"
+                    else:
+                        processed_line = convert_chords_to_chordpro(line)
+
+                for processed in processed_line.split("\n"):
+                    if processed.strip():
+                        lines.append(processed)
+
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_song_chordpro(
+    gdrive_client: GoogleDriveClient,
+    file_id: str,
+    file_name: str,
+    destination_path: Path,
+    include_annotations: bool = True,
+    detect_sections: bool = False,
+) -> None:
+    """Generate a ChordPro file from a Google Drive song document."""
+    text = gdrive_client.export_file_as_text(file_id, cache_prefix="song-chordpro")
+
+    title, sections = parse_doc_text(text, include_annotations=include_annotations)
+    metadata = parse_metadata(text)
+
+    artist = ""
+    if " - " in title:
+        title, artist = title.split(" - ", 1)
+
+    chordpro_content = build_chordpro(
+        title,
+        artist,
+        sections,
+        metadata,
+        include_annotations=include_annotations,
+        detect_sections=detect_sections,
+    )
+
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    destination_path.write_text(chordpro_content, encoding="utf-8")

--- a/generator/worker/chordpro.py
+++ b/generator/worker/chordpro.py
@@ -104,6 +104,21 @@ def strip_annotations(text: str) -> str | None:
     return result if result else None
 
 
+def _parse_chord_bars(text: str) -> list[list[str]]:
+    """Split chord-only text into bars using whitespace as bar boundaries.
+
+    '(C) (G)' → two bars [['C'], ['G']]
+    '(X)(X)(X)(X)' → one bar [['X', 'X', 'X', 'X']]
+    '(C) (X)(X)(X)(X) (F)' → three bars [['C'], ['X','X','X','X'], ['F']]
+    """
+    bars = []
+    for token in text.strip().split():
+        chords = _CHORD_PATTERN.findall(token)
+        if chords:
+            bars.append(chords)
+    return bars
+
+
 def parse_doc_json(
     doc_json: dict,
     include_annotations: bool = True,
@@ -142,12 +157,13 @@ def parse_doc_json(
         content_runs = [r for r in runs if r["textRun"].get("content", "").strip()]
 
         # All bold → chord-only paragraph → grid
+        # Space between chord groups = bar boundary; no space = beats within same bar
         if content_runs and all(_is_bold(r) for r in content_runs):
-            chords = _CHORD_PATTERN.findall(plain)
-            if chords:
-                grid = format_as_grid(chords, time_sig)
+            bars = _parse_chord_bars(plain)
+            if bars:
+                grid_line = "| " + " | ".join(" ".join(bar) for bar in bars) + " |"
                 current_lines.append("{start_of_grid}")
-                current_lines.extend(grid.split("\n"))
+                current_lines.append(grid_line)
                 current_lines.append("{end_of_grid}")
                 continue
 

--- a/generator/worker/chordpro.py
+++ b/generator/worker/chordpro.py
@@ -174,8 +174,8 @@ def generate_song_chordpro(
     metadata = parse_metadata(text)
 
     artist = ""
-    if " - " in title:
-        title, artist = title.split(" - ", 1)
+    if " - " in file_name:
+        artist = file_name.split(" - ", 1)[1]
 
     chordpro_content = build_chordpro(
         title,

--- a/generator/worker/chordpro.py
+++ b/generator/worker/chordpro.py
@@ -163,27 +163,43 @@ def parse_doc_json(
 
         runs = [el for el in para.get("elements", []) if "textRun" in el]
         content_runs = [r for r in runs if r["textRun"].get("content", "").strip()]
-
-        # All bold → chord-only paragraph → grid
-        # Space between chord groups = bar boundary; no space = beats within same bar
-        if content_runs and all(_is_bold(r) for r in content_runs):
-            bars = _parse_chord_bars(plain, time_sig)
-            if bars:
-                grid_line = "| " + " | ".join(" ".join(bar) for bar in bars) + " |"
-                current_lines.append("{start_of_grid}")
-                current_lines.append(grid_line)
-                current_lines.append("{end_of_grid}")
-                continue
+        italic_runs = [r for r in content_runs if _is_italic(r)]
+        non_italic_runs = [r for r in content_runs if not _is_italic(r)]
 
         # All italic → standalone annotation paragraph
-        if content_runs and all(_is_italic(r) for r in content_runs):
+        if content_runs and not non_italic_runs:
             if include_annotations:
                 annotation_text = plain.strip("[]() \t")
                 current_lines.append(f"{{comment: {annotation_text}}}")
             continue
 
-        # Mixed paragraph: process run by run
+        # All non-italic content is bold → chord-only paragraph (possibly with italic annotation prefix)
+        # Consecutive bold runs are merged before regex matching to handle chords split across runs
+        if non_italic_runs and all(_is_bold(r) for r in non_italic_runs):
+            if include_annotations and italic_runs:
+                annotation_text = "".join(
+                    r["textRun"].get("content", "") for r in italic_runs
+                ).strip("[]() \t")
+                if annotation_text:
+                    current_lines.append(f"{{comment: {annotation_text}}}")
+
+            bold_text = "".join(
+                r["textRun"].get("content", "").rstrip("\n")
+                for r in runs
+                if _is_bold(r)
+            )
+            bars = _parse_chord_bars(bold_text.strip(), time_sig)
+            if bars:
+                grid_line = "| " + " | ".join(" ".join(bar) for bar in bars) + " |"
+                current_lines.append("{start_of_grid}")
+                current_lines.append(grid_line)
+                current_lines.append("{end_of_grid}")
+            continue
+
+        # Mixed paragraph: merge consecutive bold runs before chord conversion
+        # to handle chords split across run boundaries (e.g. "(" in one run, "Em)" in next)
         line_parts = []
+        bold_buffer = ""
         for run in runs:
             text_run = run["textRun"]
             run_content = text_run.get("content", "").rstrip("\n")
@@ -192,11 +208,16 @@ def parse_doc_json(
             style = text_run.get("textStyle", {})
 
             if style.get("bold"):
-                line_parts.append(convert_chords_to_chordpro(run_content))
-            elif style.get("italic"):
-                pass  # inline annotations don't map cleanly to ChordPro
+                bold_buffer += run_content
             else:
-                line_parts.append(run_content)
+                if bold_buffer:
+                    line_parts.append(convert_chords_to_chordpro(bold_buffer))
+                    bold_buffer = ""
+                if not style.get("italic"):
+                    line_parts.append(run_content)
+
+        if bold_buffer:
+            line_parts.append(convert_chords_to_chordpro(bold_buffer))
 
         line = "".join(line_parts).strip()
         if line:

--- a/generator/worker/test_chordpro.py
+++ b/generator/worker/test_chordpro.py
@@ -264,11 +264,11 @@ def test_parse_doc_json_skips_metadata_paragraph():
 
 
 def test_parse_doc_json_chord_only_becomes_grid():
-    _, sections = parse_doc_json(LOVE_ME_DO_DOC)
+    _, sections = parse_doc_json(LOVE_ME_DO_DOC, time_sig="4/4")
     full = "\n".join(sections)
     assert "{start_of_grid}" in full
-    # Each space-separated chord token is its own bar
-    assert "| G | C | G | C |" in full
+    # Single-chord bars are padded with dots; each space-separated token = one bar
+    assert "| G . . . | C . . . | G . . . | C . . . |" in full
     assert "{end_of_grid}" in full
 
 
@@ -344,9 +344,9 @@ def test_parse_doc_json_space_separated_chords_become_separate_bars():
             ]
         }
     }
-    _, sections = parse_doc_json(doc)
+    _, sections = parse_doc_json(doc, time_sig="4/4")
     full = "\n".join(sections)
-    assert "| G | C | G |" in full
+    assert "| G . . . | C . . . | G . . . |" in full
 
 
 def test_parse_doc_json_no_space_chords_become_one_bar():
@@ -358,7 +358,7 @@ def test_parse_doc_json_no_space_chords_become_one_bar():
             ]
         }
     }
-    _, sections = parse_doc_json(doc)
+    _, sections = parse_doc_json(doc, time_sig="4/4")
     full = "\n".join(sections)
     assert "| X X X X |" in full
 
@@ -372,9 +372,9 @@ def test_parse_doc_json_mixed_spacing():
             ]
         }
     }
-    _, sections = parse_doc_json(doc)
+    _, sections = parse_doc_json(doc, time_sig="4/4")
     full = "\n".join(sections)
-    assert "| C | X X X X | F |" in full
+    assert "| C . . . | X X X X | F . . . |" in full
 
 
 # --- build_chordpro ---
@@ -489,4 +489,5 @@ def test_generate_song_chordpro_uses_space_as_bar_boundary(tmp_path):
     generate_song_chordpro(docs_service, "file-id", "Waltz", dest)
 
     content = dest.read_text()
-    assert "| G | C | G |" in content
+    # Single-chord bars padded to 3 beats for 3/4
+    assert "| G . . | C . . | G . . |" in content

--- a/generator/worker/test_chordpro.py
+++ b/generator/worker/test_chordpro.py
@@ -1,9 +1,12 @@
+from unittest.mock import MagicMock
+
 from .chordpro import (
     build_chordpro,
     cells_per_bar,
     convert_chords_to_chordpro,
     detect_chord_only_line,
     format_as_grid,
+    generate_song_chordpro,
     parse_metadata,
     strip_annotations,
 )
@@ -313,3 +316,29 @@ def test_build_chordpro_3_4_grid():
     lines = chordpro.split("\n")
     grid_lines = [line for line in lines if "|" in line]
     assert len(grid_lines) == 2
+
+
+# --- generate_song_chordpro ---
+
+
+def test_generate_song_chordpro_artist_from_file_name(tmp_path):
+    gdrive_client = MagicMock()
+    gdrive_client.download_file.return_value = LOVE_ME_DO_TEXT.encode("utf-8")
+
+    dest = tmp_path / "love_me_do.cho"
+    generate_song_chordpro(gdrive_client, "file-id", "Love Me Do - The Beatles", dest)
+
+    content = dest.read_text()
+    assert "{title: Love Me Do}" in content
+    assert "{artist: The Beatles}" in content
+
+
+def test_generate_song_chordpro_no_artist_when_no_dash(tmp_path):
+    gdrive_client = MagicMock()
+    gdrive_client.download_file.return_value = b"Untitled\n\n(G)Some lyrics\n"
+
+    dest = tmp_path / "untitled.cho"
+    generate_song_chordpro(gdrive_client, "file-id", "Untitled", dest)
+
+    content = dest.read_text()
+    assert "{artist:" not in content

--- a/generator/worker/test_chordpro.py
+++ b/generator/worker/test_chordpro.py
@@ -1,5 +1,3 @@
-import pytest
-
 from .chordpro import (
     build_chordpro,
     cells_per_bar,
@@ -313,5 +311,5 @@ def test_build_chordpro_3_4_grid():
     )
     assert "{start_of_grid}" in chordpro
     lines = chordpro.split("\n")
-    grid_lines = [l for l in lines if "|" in l]
+    grid_lines = [line for line in lines if "|" in line]
     assert len(grid_lines) == 2

--- a/generator/worker/test_chordpro.py
+++ b/generator/worker/test_chordpro.py
@@ -1,0 +1,317 @@
+import pytest
+
+from .chordpro import (
+    build_chordpro,
+    cells_per_bar,
+    convert_chords_to_chordpro,
+    detect_chord_only_line,
+    format_as_grid,
+    parse_metadata,
+    strip_annotations,
+)
+
+LOVE_ME_DO_TEXT = """\
+Love Me Do - The Beatles
+
+(Backing vocals)    Harmonies    148bpm    4/4    swing
+
+[harmonica]
+
+(G) (C) (G) (C)
+(G)Love, love me do (C)
+You (G)know I love you (C)
+I'll (G)always be true (C)
+"""
+
+
+# --- parse_metadata ---
+
+
+def test_parse_metadata_bpm():
+    metadata = parse_metadata(LOVE_ME_DO_TEXT)
+    assert metadata["tempo"] == 148
+
+
+def test_parse_metadata_time_sig():
+    metadata = parse_metadata(LOVE_ME_DO_TEXT)
+    assert metadata["time_sig"] == "4/4"
+
+
+def test_parse_metadata_missing_bpm():
+    text = "Song Title\n\n4/4"
+    metadata = parse_metadata(text)
+    assert metadata["tempo"] is None
+    assert metadata["time_sig"] == "4/4"
+
+
+def test_parse_metadata_missing_time_sig():
+    text = "Song Title\n\n120bpm"
+    metadata = parse_metadata(text)
+    assert metadata["tempo"] == 120
+    assert metadata["time_sig"] is None
+
+
+def test_parse_metadata_both_missing():
+    text = "Song Title\n\nJust lyrics"
+    metadata = parse_metadata(text)
+    assert metadata["tempo"] is None
+    assert metadata["time_sig"] is None
+
+
+# --- cells_per_bar ---
+
+
+def test_cells_per_bar_4_4():
+    assert cells_per_bar("4/4") == 4
+
+
+def test_cells_per_bar_3_4():
+    assert cells_per_bar("3/4") == 3
+
+
+def test_cells_per_bar_6_8():
+    assert cells_per_bar("6/8") == 6
+
+
+def test_cells_per_bar_none():
+    assert cells_per_bar(None) == 4
+
+
+def test_cells_per_bar_invalid():
+    assert cells_per_bar("invalid") == 4
+
+
+# --- detect_chord_only_line ---
+
+
+def test_detect_chord_only_line_true():
+    is_chord_only, chords = detect_chord_only_line("(G) (C) (G) (C)")
+    assert is_chord_only is True
+    assert chords == ["G", "C", "G", "C"]
+
+
+def test_detect_chord_only_line_with_lyrics():
+    is_chord_only, chords = detect_chord_only_line("(G)Love me do (C)")
+    assert is_chord_only is False
+    assert chords == ["G", "C"]
+
+
+def test_detect_chord_only_line_no_chords():
+    is_chord_only, chords = detect_chord_only_line("Love me do")
+    assert is_chord_only is False
+    assert chords == []
+
+
+def test_detect_chord_only_line_whitespace_only():
+    is_chord_only, chords = detect_chord_only_line("   ")
+    assert is_chord_only is False
+    assert chords == []
+
+
+# --- format_as_grid ---
+
+
+def test_format_as_grid_4_4():
+    chords = ["G", "C", "G", "C"]
+    grid = format_as_grid(chords, "4/4")
+    expected = "| G C G C |"
+    assert grid == expected
+
+
+def test_format_as_grid_3_4():
+    chords = ["G", "C", "G", "C", "D"]
+    grid = format_as_grid(chords, "3/4")
+    lines = grid.split("\n")
+    assert len(lines) == 2
+    assert "G C G" in lines[0]
+    assert "C D ." in lines[1]
+
+
+def test_format_as_grid_partial_bar():
+    chords = ["G", "C"]
+    grid = format_as_grid(chords, "4/4")
+    assert "G C . ." in grid
+
+
+def test_format_as_grid_empty():
+    grid = format_as_grid([], "4/4")
+    assert grid == ""
+
+
+def test_format_as_grid_6_8():
+    chords = ["G", "C", "G", "C", "G", "C", "D"]
+    grid = format_as_grid(chords, "6/8")
+    lines = grid.split("\n")
+    assert len(lines) == 2
+    assert "G C G C G C" in lines[0]
+    assert "D . . . . ." in lines[1]
+
+
+# --- convert_chords_to_chordpro ---
+
+
+def test_convert_chords_to_chordpro():
+    text = "(G)Love me do (C)"
+    result = convert_chords_to_chordpro(text)
+    assert result == "[G]Love me do [C]"
+
+
+def test_convert_chords_to_chordpro_no_chords():
+    text = "Love me do"
+    result = convert_chords_to_chordpro(text)
+    assert result == "Love me do"
+
+
+def test_convert_chords_to_chordpro_complex_chord():
+    text = "(G/B)Love (Cm7)me"
+    result = convert_chords_to_chordpro(text)
+    assert result == "[G/B]Love [Cm7]me"
+
+
+# --- strip_annotations ---
+
+
+def test_strip_annotations_stage_direction():
+    result = strip_annotations("[harmonica]")
+    assert result is None
+
+
+def test_strip_annotations_inline():
+    result = strip_annotations("[all] (G)Love me do (C)")
+    assert result == "(G)Love me do (C)"
+
+
+def test_strip_annotations_mid_line():
+    result = strip_annotations("(G) (G) [no ukes] (D7)")
+    assert result == "(G) (G) (D7)"
+
+
+def test_strip_annotations_no_annotations():
+    result = strip_annotations("(G)Love me do (C)")
+    assert result == "(G)Love me do (C)"
+
+
+def test_strip_annotations_multiple():
+    result = strip_annotations("[intro] (G) [verse] (C)")
+    assert result == "(G) (C)"
+
+
+# --- build_chordpro ---
+
+
+def test_build_chordpro_basic():
+    chordpro = build_chordpro(
+        "Love Me Do",
+        "The Beatles",
+        ["(G)Love, love me do (C)"],
+        {"tempo": 148, "time_sig": "4/4"},
+        include_annotations=True,
+    )
+    assert "{title: Love Me Do}" in chordpro
+    assert "{artist: The Beatles}" in chordpro
+    assert "{tempo: 148}" in chordpro
+    assert "{time: 4/4}" in chordpro
+    assert "[G]Love, love me do [C]" in chordpro
+
+
+def test_build_chordpro_no_artist():
+    chordpro = build_chordpro(
+        "Untitled",
+        "",
+        ["(G)Some lyrics"],
+        {},
+        include_annotations=True,
+    )
+    assert "{title: Untitled}" in chordpro
+    assert "{artist:" not in chordpro
+
+
+def test_build_chordpro_chord_only_line():
+    chordpro = build_chordpro(
+        "Test Song",
+        "Artist",
+        ["(G) (C) (G) (C)"],
+        {"time_sig": "4/4"},
+        include_annotations=True,
+    )
+    assert "{start_of_grid}" in chordpro
+    assert "{end_of_grid}" in chordpro
+    assert "| G C G C |" in chordpro
+
+
+def test_build_chordpro_strip_annotations():
+    chordpro = build_chordpro(
+        "Test",
+        "Artist",
+        ["[verse]\n(G)Love me do (C)"],
+        {"time_sig": "4/4"},
+        include_annotations=False,
+    )
+    assert "[verse]" not in chordpro
+    assert "[G]Love me do [C]" in chordpro
+
+
+def test_build_chordpro_keep_annotations():
+    chordpro = build_chordpro(
+        "Test",
+        "Artist",
+        ["[harmonica]\n(G)Love me do (C)"],
+        {"time_sig": "4/4"},
+        include_annotations=True,
+    )
+    assert "{comment: harmonica}" in chordpro
+    assert "[G]Love me do [C]" in chordpro
+
+
+def test_build_chordpro_multiple_sections():
+    sections = [
+        "(G)First verse (C)",
+        "(D)Second verse (A)",
+        "(G) (C) (G) (C)",
+    ]
+    chordpro = build_chordpro(
+        "Multi",
+        "Artist",
+        sections,
+        {"time_sig": "4/4"},
+        include_annotations=True,
+    )
+    assert "[G]First verse [C]" in chordpro
+    assert "[D]Second verse [A]" in chordpro
+    assert "{start_of_grid}" in chordpro
+
+
+def test_build_chordpro_ends_with_newline():
+    chordpro = build_chordpro(
+        "Test",
+        "Artist",
+        [],
+        {},
+        include_annotations=True,
+    )
+    assert chordpro.endswith("\n")
+
+
+def test_build_chordpro_empty_sections():
+    chordpro = build_chordpro(
+        "Test",
+        "Artist",
+        ["", "(G)Verse (C)", ""],
+        {"time_sig": "4/4"},
+        include_annotations=True,
+    )
+    assert "[G]Verse [C]" in chordpro
+
+
+def test_build_chordpro_3_4_grid():
+    chordpro = build_chordpro(
+        "Waltz",
+        "Artist",
+        ["(G) (C) (G) (C) (D)"],
+        {"time_sig": "3/4"},
+        include_annotations=True,
+    )
+    assert "{start_of_grid}" in chordpro
+    lines = chordpro.split("\n")
+    grid_lines = [l for l in lines if "|" in l]
+    assert len(grid_lines) == 2

--- a/generator/worker/test_chordpro.py
+++ b/generator/worker/test_chordpro.py
@@ -267,7 +267,8 @@ def test_parse_doc_json_chord_only_becomes_grid():
     _, sections = parse_doc_json(LOVE_ME_DO_DOC)
     full = "\n".join(sections)
     assert "{start_of_grid}" in full
-    assert "| G C G C |" in full
+    # Each space-separated chord token is its own bar
+    assert "| G | C | G | C |" in full
     assert "{end_of_grid}" in full
 
 
@@ -330,7 +331,7 @@ def test_parse_doc_json_empty_doc():
     assert sections == []
 
 
-def test_parse_doc_json_time_sig_used_for_grid():
+def test_parse_doc_json_space_separated_chords_become_separate_bars():
     doc = {
         "body": {
             "content": [
@@ -343,9 +344,37 @@ def test_parse_doc_json_time_sig_used_for_grid():
             ]
         }
     }
-    _, sections = parse_doc_json(doc, time_sig="3/4")
+    _, sections = parse_doc_json(doc)
     full = "\n".join(sections)
-    assert "| G C G |" in full
+    assert "| G | C | G |" in full
+
+
+def test_parse_doc_json_no_space_chords_become_one_bar():
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Song\n")),
+                _para(_text_run("(X)(X)(X)(X)\n", bold=True)),
+            ]
+        }
+    }
+    _, sections = parse_doc_json(doc)
+    full = "\n".join(sections)
+    assert "| X X X X |" in full
+
+
+def test_parse_doc_json_mixed_spacing():
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Song\n")),
+                _para(_text_run("(C) (X)(X)(X)(X) (F)\n", bold=True)),
+            ]
+        }
+    }
+    _, sections = parse_doc_json(doc)
+    full = "\n".join(sections)
+    assert "| C | X X X X | F |" in full
 
 
 # --- build_chordpro ---
@@ -439,7 +468,7 @@ def test_generate_song_chordpro_no_artist_when_no_dash(tmp_path):
     assert "{artist:" not in content
 
 
-def test_generate_song_chordpro_uses_time_sig_for_grid(tmp_path):
+def test_generate_song_chordpro_uses_space_as_bar_boundary(tmp_path):
     doc = {
         "body": {
             "content": [
@@ -460,4 +489,4 @@ def test_generate_song_chordpro_uses_time_sig_for_grid(tmp_path):
     generate_song_chordpro(docs_service, "file-id", "Waltz", dest)
 
     content = dest.read_text()
-    assert "| G C G |" in content
+    assert "| G | C | G |" in content

--- a/generator/worker/test_chordpro.py
+++ b/generator/worker/test_chordpro.py
@@ -7,54 +7,105 @@ from .chordpro import (
     detect_chord_only_line,
     format_as_grid,
     generate_song_chordpro,
+    parse_doc_json,
     parse_metadata,
+    parse_metadata_from_json,
     strip_annotations,
 )
 
-LOVE_ME_DO_TEXT = """\
-Love Me Do - The Beatles
 
-(Backing vocals)    Harmonies    148bpm    4/4    swing
+def _text_run(content, bold=False, italic=False):
+    style = {}
+    if bold:
+        style["bold"] = True
+    if italic:
+        style["italic"] = True
+    return {"textRun": {"content": content, "textStyle": style}}
 
-[harmonica]
 
-(G) (C) (G) (C)
-(G)Love, love me do (C)
-You (G)know I love you (C)
-I'll (G)always be true (C)
-"""
+def _para(*runs):
+    return {"paragraph": {"elements": list(runs)}}
+
+
+# Minimal Docs API JSON fixture for Love Me Do
+LOVE_ME_DO_DOC = {
+    "body": {
+        "content": [
+            _para(_text_run("Love Me Do - The Beatles\n")),
+            _para(
+                _text_run("(Backing vocals)    ", italic=True),
+                _text_run("Harmonies    148bpm    4/4    swing\n"),
+            ),
+            _para(_text_run("[harmonica]\n", italic=True)),
+            _para(_text_run("\n")),
+            _para(
+                _text_run("(G) ", bold=True),
+                _text_run("(C) ", bold=True),
+                _text_run("(G) ", bold=True),
+                _text_run("(C)\n", bold=True),
+            ),
+            _para(
+                _text_run("(G)", bold=True),
+                _text_run("Love, love me do "),
+                _text_run("(C)\n", bold=True),
+            ),
+            _para(
+                _text_run("You "),
+                _text_run("(G)", bold=True),
+                _text_run("know I love you "),
+                _text_run("(C)\n", bold=True),
+            ),
+        ]
+    }
+}
 
 
 # --- parse_metadata ---
 
 
 def test_parse_metadata_bpm():
-    metadata = parse_metadata(LOVE_ME_DO_TEXT)
+    metadata = parse_metadata("148bpm    4/4    swing")
     assert metadata["tempo"] == 148
 
 
 def test_parse_metadata_time_sig():
-    metadata = parse_metadata(LOVE_ME_DO_TEXT)
+    metadata = parse_metadata("148bpm    4/4    swing")
     assert metadata["time_sig"] == "4/4"
 
 
 def test_parse_metadata_missing_bpm():
-    text = "Song Title\n\n4/4"
-    metadata = parse_metadata(text)
+    metadata = parse_metadata("4/4")
     assert metadata["tempo"] is None
     assert metadata["time_sig"] == "4/4"
 
 
 def test_parse_metadata_missing_time_sig():
-    text = "Song Title\n\n120bpm"
-    metadata = parse_metadata(text)
+    metadata = parse_metadata("120bpm")
     assert metadata["tempo"] == 120
     assert metadata["time_sig"] is None
 
 
 def test_parse_metadata_both_missing():
-    text = "Song Title\n\nJust lyrics"
-    metadata = parse_metadata(text)
+    metadata = parse_metadata("Just lyrics")
+    assert metadata["tempo"] is None
+    assert metadata["time_sig"] is None
+
+
+# --- parse_metadata_from_json ---
+
+
+def test_parse_metadata_from_json_bpm():
+    metadata = parse_metadata_from_json(LOVE_ME_DO_DOC)
+    assert metadata["tempo"] == 148
+
+
+def test_parse_metadata_from_json_time_sig():
+    metadata = parse_metadata_from_json(LOVE_ME_DO_DOC)
+    assert metadata["time_sig"] == "4/4"
+
+
+def test_parse_metadata_from_json_empty_doc():
+    metadata = parse_metadata_from_json({"body": {"content": []}})
     assert metadata["tempo"] is None
     assert metadata["time_sig"] is None
 
@@ -197,6 +248,106 @@ def test_strip_annotations_multiple():
     assert result == "(G) (C)"
 
 
+# --- parse_doc_json ---
+
+
+def test_parse_doc_json_title():
+    title, _ = parse_doc_json(LOVE_ME_DO_DOC)
+    assert title == "Love Me Do"
+
+
+def test_parse_doc_json_skips_metadata_paragraph():
+    _, sections = parse_doc_json(LOVE_ME_DO_DOC)
+    full = "\n".join(sections)
+    assert "148bpm" not in full
+    assert "4/4" not in full
+
+
+def test_parse_doc_json_chord_only_becomes_grid():
+    _, sections = parse_doc_json(LOVE_ME_DO_DOC)
+    full = "\n".join(sections)
+    assert "{start_of_grid}" in full
+    assert "| G C G C |" in full
+    assert "{end_of_grid}" in full
+
+
+def test_parse_doc_json_annotation_paragraph_kept():
+    _, sections = parse_doc_json(LOVE_ME_DO_DOC, include_annotations=True)
+    full = "\n".join(sections)
+    assert "{comment: harmonica}" in full
+
+
+def test_parse_doc_json_annotation_paragraph_stripped():
+    _, sections = parse_doc_json(LOVE_ME_DO_DOC, include_annotations=False)
+    full = "\n".join(sections)
+    assert "harmonica" not in full
+
+
+def test_parse_doc_json_inline_chords():
+    _, sections = parse_doc_json(LOVE_ME_DO_DOC)
+    full = "\n".join(sections)
+    assert "[G]Love, love me do [C]" in full
+    assert "You [G]know I love you [C]" in full
+
+
+def test_parse_doc_json_inline_italic_stripped():
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Song\n")),
+                _para(
+                    _text_run("(G)", bold=True),
+                    _text_run("do ", italic=True),
+                    _text_run("lyrics"),
+                ),
+            ]
+        }
+    }
+    _, sections = parse_doc_json(doc)
+    assert "do" not in sections[0]
+    assert "[G]" in sections[0]
+    assert "lyrics" in sections[0]
+
+
+def test_parse_doc_json_section_split_on_empty_para():
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Song\n")),
+                _para(_text_run("(G)", bold=True), _text_run("first\n")),
+                _para(_text_run("\n")),
+                _para(_text_run("(C)", bold=True), _text_run("second\n")),
+            ]
+        }
+    }
+    _, sections = parse_doc_json(doc)
+    assert len(sections) == 2
+
+
+def test_parse_doc_json_empty_doc():
+    title, sections = parse_doc_json({"body": {"content": []}})
+    assert title == "Untitled"
+    assert sections == []
+
+
+def test_parse_doc_json_time_sig_used_for_grid():
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Song\n")),
+                _para(
+                    _text_run("(G) ", bold=True),
+                    _text_run("(C) ", bold=True),
+                    _text_run("(G)\n", bold=True),
+                ),
+            ]
+        }
+    }
+    _, sections = parse_doc_json(doc, time_sig="3/4")
+    full = "\n".join(sections)
+    assert "| G C G |" in full
+
+
 # --- build_chordpro ---
 
 
@@ -204,9 +355,8 @@ def test_build_chordpro_basic():
     chordpro = build_chordpro(
         "Love Me Do",
         "The Beatles",
-        ["(G)Love, love me do (C)"],
+        ["[G]Love, love me do [C]"],
         {"tempo": 148, "time_sig": "4/4"},
-        include_annotations=True,
     )
     assert "{title: Love Me Do}" in chordpro
     assert "{artist: The Beatles}" in chordpro
@@ -216,117 +366,54 @@ def test_build_chordpro_basic():
 
 
 def test_build_chordpro_no_artist():
-    chordpro = build_chordpro(
-        "Untitled",
-        "",
-        ["(G)Some lyrics"],
-        {},
-        include_annotations=True,
-    )
+    chordpro = build_chordpro("Untitled", "", ["[G]Some lyrics"], {})
     assert "{title: Untitled}" in chordpro
     assert "{artist:" not in chordpro
 
 
-def test_build_chordpro_chord_only_line():
-    chordpro = build_chordpro(
-        "Test Song",
-        "Artist",
-        ["(G) (C) (G) (C)"],
-        {"time_sig": "4/4"},
-        include_annotations=True,
-    )
+def test_build_chordpro_pre_formatted_grid():
+    section = "{start_of_grid}\n| G C G C |\n{end_of_grid}"
+    chordpro = build_chordpro("Test", "Artist", [section], {"time_sig": "4/4"})
     assert "{start_of_grid}" in chordpro
-    assert "{end_of_grid}" in chordpro
     assert "| G C G C |" in chordpro
-
-
-def test_build_chordpro_strip_annotations():
-    chordpro = build_chordpro(
-        "Test",
-        "Artist",
-        ["[verse]\n(G)Love me do (C)"],
-        {"time_sig": "4/4"},
-        include_annotations=False,
-    )
-    assert "[verse]" not in chordpro
-    assert "[G]Love me do [C]" in chordpro
-
-
-def test_build_chordpro_keep_annotations():
-    chordpro = build_chordpro(
-        "Test",
-        "Artist",
-        ["[harmonica]\n(G)Love me do (C)"],
-        {"time_sig": "4/4"},
-        include_annotations=True,
-    )
-    assert "{comment: harmonica}" in chordpro
-    assert "[G]Love me do [C]" in chordpro
+    assert "{end_of_grid}" in chordpro
 
 
 def test_build_chordpro_multiple_sections():
     sections = [
-        "(G)First verse (C)",
-        "(D)Second verse (A)",
-        "(G) (C) (G) (C)",
+        "[G]First verse [C]",
+        "[D]Second verse [A]",
+        "{start_of_grid}\n| G C G C |\n{end_of_grid}",
     ]
-    chordpro = build_chordpro(
-        "Multi",
-        "Artist",
-        sections,
-        {"time_sig": "4/4"},
-        include_annotations=True,
-    )
+    chordpro = build_chordpro("Multi", "Artist", sections, {"time_sig": "4/4"})
     assert "[G]First verse [C]" in chordpro
     assert "[D]Second verse [A]" in chordpro
     assert "{start_of_grid}" in chordpro
 
 
 def test_build_chordpro_ends_with_newline():
-    chordpro = build_chordpro(
-        "Test",
-        "Artist",
-        [],
-        {},
-        include_annotations=True,
-    )
+    chordpro = build_chordpro("Test", "Artist", [], {})
     assert chordpro.endswith("\n")
 
 
-def test_build_chordpro_empty_sections():
+def test_build_chordpro_empty_sections_skipped():
     chordpro = build_chordpro(
-        "Test",
-        "Artist",
-        ["", "(G)Verse (C)", ""],
-        {"time_sig": "4/4"},
-        include_annotations=True,
+        "Test", "Artist", ["", "[G]Verse [C]", ""], {"time_sig": "4/4"}
     )
     assert "[G]Verse [C]" in chordpro
-
-
-def test_build_chordpro_3_4_grid():
-    chordpro = build_chordpro(
-        "Waltz",
-        "Artist",
-        ["(G) (C) (G) (C) (D)"],
-        {"time_sig": "3/4"},
-        include_annotations=True,
-    )
-    assert "{start_of_grid}" in chordpro
-    lines = chordpro.split("\n")
-    grid_lines = [line for line in lines if "|" in line]
-    assert len(grid_lines) == 2
 
 
 # --- generate_song_chordpro ---
 
 
 def test_generate_song_chordpro_artist_from_file_name(tmp_path):
-    gdrive_client = MagicMock()
-    gdrive_client.download_file.return_value = LOVE_ME_DO_TEXT.encode("utf-8")
+    docs_service = MagicMock()
+    docs_service.documents().get(
+        documentId="file-id"
+    ).execute.return_value = LOVE_ME_DO_DOC
 
     dest = tmp_path / "love_me_do.cho"
-    generate_song_chordpro(gdrive_client, "file-id", "Love Me Do - The Beatles", dest)
+    generate_song_chordpro(docs_service, "file-id", "Love Me Do - The Beatles", dest)
 
     content = dest.read_text()
     assert "{title: Love Me Do}" in content
@@ -334,11 +421,43 @@ def test_generate_song_chordpro_artist_from_file_name(tmp_path):
 
 
 def test_generate_song_chordpro_no_artist_when_no_dash(tmp_path):
-    gdrive_client = MagicMock()
-    gdrive_client.download_file.return_value = b"Untitled\n\n(G)Some lyrics\n"
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Untitled\n")),
+                _para(_text_run("(G)", bold=True), _text_run("Some lyrics\n")),
+            ]
+        }
+    }
+    docs_service = MagicMock()
+    docs_service.documents().get(documentId="file-id").execute.return_value = doc
 
     dest = tmp_path / "untitled.cho"
-    generate_song_chordpro(gdrive_client, "file-id", "Untitled", dest)
+    generate_song_chordpro(docs_service, "file-id", "Untitled", dest)
 
     content = dest.read_text()
     assert "{artist:" not in content
+
+
+def test_generate_song_chordpro_uses_time_sig_for_grid(tmp_path):
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Waltz\n")),
+                _para(_text_run("3/4    90bpm\n")),
+                _para(
+                    _text_run("(G) ", bold=True),
+                    _text_run("(C) ", bold=True),
+                    _text_run("(G)\n", bold=True),
+                ),
+            ]
+        }
+    }
+    docs_service = MagicMock()
+    docs_service.documents().get(documentId="file-id").execute.return_value = doc
+
+    dest = tmp_path / "waltz.cho"
+    generate_song_chordpro(docs_service, "file-id", "Waltz", dest)
+
+    content = dest.read_text()
+    assert "| G C G |" in content

--- a/generator/worker/test_chordpro.py
+++ b/generator/worker/test_chordpro.py
@@ -310,6 +310,47 @@ def test_parse_doc_json_inline_italic_stripped():
     assert "lyrics" in sections[0]
 
 
+def test_parse_doc_json_chord_split_across_runs():
+    # '(' in one run, 'Em)' in next — both bold — should still convert
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Song\n")),
+                _para(
+                    _text_run("(", bold=True),
+                    _text_run("Em) ", bold=True),
+                    _text_run("(", bold=True),
+                    _text_run("C)\n", bold=True),
+                ),
+            ]
+        }
+    }
+    _, sections = parse_doc_json(doc, time_sig="4/4")
+    full = "\n".join(sections)
+    assert "| Em . . . | C . . . |" in full
+
+
+def test_parse_doc_json_italic_annotation_prefix_with_chord_only():
+    # Italic annotation + bold chords → comment + grid
+    doc = {
+        "body": {
+            "content": [
+                _para(_text_run("Song\n")),
+                _para(
+                    _text_run("[ukes only] ", italic=True),
+                    _text_run("(Em) ", bold=True),
+                    _text_run("(C)\n", bold=True),
+                ),
+            ]
+        }
+    }
+    _, sections = parse_doc_json(doc, include_annotations=True, time_sig="4/4")
+    full = "\n".join(sections)
+    assert "{comment: ukes only}" in full
+    assert "{start_of_grid}" in full
+    assert "| Em . . . | C . . . |" in full
+
+
 def test_parse_doc_json_section_split_on_empty_para():
     doc = {
         "body": {


### PR DESCRIPTION
## Summary
- Adds new `generate-chordpro` CLI command for exporting songs to ChordPro v6 format
- Converts chord notation from (chord) to [chord] syntax
- Formats chord-only lines as structured ChordPro grids (respects time signatures)
- Extracts metadata (BPM, time signature) from song documents
- Supports --no-annotations flag to strip stage directions
- Future-ready for --detect-sections feature (optional auto-detection)

## ChordPro Features
- Plain-text, human-readable format
- Widely supported by music apps (OnSong, Chordify, etc.)
- Machine-readable grids for transposition and chord analysis
- Metadata directives: {title}, {artist}, {tempo}, {time}, {comment}

## Test plan
- [ ] Run unit tests: `uv run pytest generator/worker/test_chordpro.py -v`
- [ ] Test basic export: `uv run songbook-tools generate-chordpro "Love Me Do" -d /tmp/test.cho`
- [ ] Verify output in ChordFiddle renderer: https://martijnversluis.github.io/ChordFiddle/
- [ ] Test with --no-annotations flag
- [ ] Verify pre-commit checks pass: `uvx pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)