### PR TITLE
Add changelog generation to songbook manifest publishing

### DIFF
--- a/.github/scripts/compute-changelog.py
+++ b/.github/scripts/compute-changelog.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Enrich a songbook manifest with an added/removed-songs changelog.
+
+Usage:
+    compute-changelog.py <new-manifest> <previous-manifest|"none"> [previous-manifest-filename]
+
+Diffs the new manifest's ``content_info.file_names`` against the previously
+published manifest and writes a top-level ``changelog`` object into the new
+manifest in place. If the previous manifest is missing, the literal string
+``none``, or unparseable, an empty changelog is written (first-run behaviour).
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+
+def load_file_names(manifest: dict[str, Any]) -> list[str]:
+    """Safely read the list of song file names from a manifest dict."""
+    return manifest.get("content_info", {}).get("file_names", []) or []
+
+
+def compute_changelog(
+    new_names: list[str],
+    old_names: Optional[list[str]],
+    previous_manifest: Optional[str],
+    previous_generated_at: Optional[str],
+) -> dict[str, Any]:
+    """Compute the changelog object diffing new vs. previous song lists.
+
+    Pure function (no I/O). ``old_names`` of ``None`` means there is no
+    previous published manifest (first run), which yields empty added/removed
+    lists so a brand-new edition does not report every song as "added".
+    """
+    if old_names is None:
+        added: list[str] = []
+        removed: list[str] = []
+    else:
+        old_set = set(old_names)
+        new_set = set(new_names)
+        added = sorted(new_set - old_set)
+        removed = sorted(old_set - new_set)
+    return {
+        "previous_manifest": previous_manifest,
+        "previous_generated_at": previous_generated_at,
+        "added": added,
+        "removed": removed,
+        "added_count": len(added),
+        "removed_count": len(removed),
+    }
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(
+            f"Usage: {Path(sys.argv[0]).name} "
+            '<new-manifest> <previous-manifest|"none"> [previous-manifest-filename]',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    new_manifest_path = Path(sys.argv[1])
+    previous_arg = sys.argv[2]
+    previous_name = sys.argv[3] if len(sys.argv) >= 4 and sys.argv[3] else None
+
+    # The new manifest must exist and be readable; anything else is a real error.
+    try:
+        new_manifest = _load_manifest(new_manifest_path)
+    except (OSError, ValueError) as e:
+        print(f"Error: could not read new manifest {new_manifest_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    old_names: Optional[list[str]] = None
+    previous_generated_at: Optional[str] = None
+    previous_manifest_ref: Optional[str] = None
+
+    if previous_arg != "none":
+        previous_path = Path(previous_arg)
+        try:
+            previous_manifest = _load_manifest(previous_path)
+            old_names = load_file_names(previous_manifest)
+            previous_generated_at = previous_manifest.get("generated_at")
+            previous_manifest_ref = previous_name or previous_path.name
+        except (OSError, ValueError) as e:
+            # First-run / corrupt previous: degrade to an empty changelog.
+            print(
+                f"Warning: could not read previous manifest {previous_path}: {e}; "
+                "writing empty changelog.",
+                file=sys.stderr,
+            )
+
+    changelog = compute_changelog(
+        new_names=load_file_names(new_manifest),
+        old_names=old_names,
+        previous_manifest=previous_manifest_ref,
+        previous_generated_at=previous_generated_at,
+    )
+    new_manifest["changelog"] = changelog
+
+    with open(new_manifest_path, "w", encoding="utf-8") as f:
+        json.dump(new_manifest, f, indent=2)
+
+    print(
+        f"✅ Wrote changelog to {new_manifest_path}: "
+        f"{changelog['added_count']} added, {changelog['removed_count']} removed "
+        f"(previous: {previous_manifest_ref or '<none>'})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/compute-changelog.py
+++ b/.github/scripts/compute-changelog.py
@@ -76,7 +76,10 @@ def main() -> None:
     try:
         new_manifest = _load_manifest(new_manifest_path)
     except (OSError, ValueError) as e:
-        print(f"Error: could not read new manifest {new_manifest_path}: {e}", file=sys.stderr)
+        print(
+            f"Error: could not read new manifest {new_manifest_path}: {e}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     old_names: Optional[list[str]] = None

--- a/.github/scripts/test_compute_changelog.py
+++ b/.github/scripts/test_compute_changelog.py
@@ -87,7 +87,8 @@ def test_main_enriches_manifest_in_place(tmp_path, monkeypatch):
     _write_manifest(old, ["A", "C", "D"], generated_at="2026-05-31T03:00:00+00:00")
 
     monkeypatch.setattr(
-        ccl.sys, "argv",
+        ccl.sys,
+        "argv",
         ["compute-changelog.py", str(new), str(old), "old-name.manifest.json"],
     )
     ccl.main()
@@ -122,7 +123,9 @@ def test_main_missing_previous_degrades(tmp_path, monkeypatch):
     _write_manifest(new, ["A", "B"])
     missing = tmp_path / "does-not-exist.json"
 
-    monkeypatch.setattr(ccl.sys, "argv", ["compute-changelog.py", str(new), str(missing)])
+    monkeypatch.setattr(
+        ccl.sys, "argv", ["compute-changelog.py", str(new), str(missing)]
+    )
     ccl.main()
 
     result = json.loads(new.read_text())

--- a/.github/scripts/test_compute_changelog.py
+++ b/.github/scripts/test_compute_changelog.py
@@ -1,0 +1,130 @@
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent / "compute-changelog.py"
+_spec = importlib.util.spec_from_file_location("compute_changelog", _SCRIPT)
+ccl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ccl)
+
+
+def test_basic_add_and_remove():
+    result = ccl.compute_changelog(
+        new_names=["A", "B", "C"],
+        old_names=["A", "C", "D"],
+        previous_manifest="prev.manifest.json",
+        previous_generated_at="2026-05-31T03:00:00+00:00",
+    )
+    assert result == {
+        "previous_manifest": "prev.manifest.json",
+        "previous_generated_at": "2026-05-31T03:00:00+00:00",
+        "added": ["B"],
+        "removed": ["D"],
+        "added_count": 1,
+        "removed_count": 1,
+    }
+
+
+def test_added_is_sorted():
+    result = ccl.compute_changelog(
+        new_names=["Z", "A"],
+        old_names=[],
+        previous_manifest="prev.manifest.json",
+        previous_generated_at="2026-05-31T03:00:00+00:00",
+    )
+    assert result["added"] == ["A", "Z"]
+    assert result["removed"] == []
+
+
+def test_first_run_no_previous():
+    result = ccl.compute_changelog(
+        new_names=["A", "B"],
+        old_names=None,
+        previous_manifest=None,
+        previous_generated_at=None,
+    )
+    assert result == {
+        "previous_manifest": None,
+        "previous_generated_at": None,
+        "added": [],
+        "removed": [],
+        "added_count": 0,
+        "removed_count": 0,
+    }
+
+
+def test_no_changes():
+    result = ccl.compute_changelog(
+        new_names=["A", "B"],
+        old_names=["B", "A"],
+        previous_manifest="prev.manifest.json",
+        previous_generated_at="2026-05-31T03:00:00+00:00",
+    )
+    assert result["added"] == []
+    assert result["removed"] == []
+    assert result["added_count"] == 0
+    assert result["removed_count"] == 0
+
+
+def test_load_file_names_missing():
+    assert ccl.load_file_names({}) == []
+    assert ccl.load_file_names({"content_info": {}}) == []
+    assert ccl.load_file_names({"content_info": {"file_names": None}}) == []
+    assert ccl.load_file_names({"content_info": {"file_names": ["X"]}}) == ["X"]
+
+
+def _write_manifest(path: Path, file_names, generated_at=None):
+    data = {"content_info": {"file_names": file_names}}
+    if generated_at is not None:
+        data["generated_at"] = generated_at
+    path.write_text(json.dumps(data))
+
+
+def test_main_enriches_manifest_in_place(tmp_path, monkeypatch):
+    new = tmp_path / "new.manifest.json"
+    old = tmp_path / "old.manifest.json"
+    _write_manifest(new, ["A", "B", "C"])
+    _write_manifest(old, ["A", "C", "D"], generated_at="2026-05-31T03:00:00+00:00")
+
+    monkeypatch.setattr(
+        ccl.sys, "argv",
+        ["compute-changelog.py", str(new), str(old), "old-name.manifest.json"],
+    )
+    ccl.main()
+
+    result = json.loads(new.read_text())
+    assert result["content_info"]["file_names"] == ["A", "B", "C"]
+    assert result["changelog"] == {
+        "previous_manifest": "old-name.manifest.json",
+        "previous_generated_at": "2026-05-31T03:00:00+00:00",
+        "added": ["B"],
+        "removed": ["D"],
+        "added_count": 1,
+        "removed_count": 1,
+    }
+
+
+def test_main_first_run_none(tmp_path, monkeypatch):
+    new = tmp_path / "new.manifest.json"
+    _write_manifest(new, ["A", "B"])
+
+    monkeypatch.setattr(ccl.sys, "argv", ["compute-changelog.py", str(new), "none"])
+    ccl.main()
+
+    result = json.loads(new.read_text())
+    assert result["changelog"]["added"] == []
+    assert result["changelog"]["removed"] == []
+    assert result["changelog"]["previous_manifest"] is None
+
+
+def test_main_missing_previous_degrades(tmp_path, monkeypatch):
+    new = tmp_path / "new.manifest.json"
+    _write_manifest(new, ["A", "B"])
+    missing = tmp_path / "does-not-exist.json"
+
+    monkeypatch.setattr(ccl.sys, "argv", ["compute-changelog.py", str(new), str(missing)])
+    ccl.main()
+
+    result = json.loads(new.read_text())
+    assert result["changelog"]["added"] == []
+    assert result["changelog"]["previous_manifest"] is None

--- a/.github/workflows/generate-songbook.yaml
+++ b/.github/workflows/generate-songbook.yaml
@@ -230,6 +230,41 @@ jobs:
         path: ./songbooks
         name: songbook-artifact-${{ needs.generate-songbook.outputs.effective_edition }}
 
+    - name: Fetch previous published manifest
+      id: fetch-previous
+      run: |
+        set -e
+        EDITION="${{ needs.generate-songbook.outputs.effective_edition }}"
+        LATEST_GCS="gs://${GCS_SONGBOOKS_BUCKET}/${EDITION}/latest.json"
+        PREV_MANIFEST_PATH="none"
+        PREV_MANIFEST_NAME=""
+        # Download the current latest.json (absent on a first-ever publish).
+        if gcloud storage cp "$LATEST_GCS" ./prev-latest.json 2>/dev/null; then
+          PREV_MANIFEST_NAME=$(jq -r '.manifest_filename // empty' ./prev-latest.json)
+          if [ -n "$PREV_MANIFEST_NAME" ]; then
+            PREV_GCS="gs://${GCS_SONGBOOKS_BUCKET}/${EDITION}/${PREV_MANIFEST_NAME}"
+            if gcloud storage cp "$PREV_GCS" ./prev-manifest.json 2>/dev/null; then
+              PREV_MANIFEST_PATH="./prev-manifest.json"
+            fi
+          fi
+        fi
+        echo "prev_manifest_path=${PREV_MANIFEST_PATH}" >> "$GITHUB_OUTPUT"
+        echo "prev_manifest_name=${PREV_MANIFEST_NAME}" >> "$GITHUB_OUTPUT"
+        echo "Previous manifest: ${PREV_MANIFEST_PATH} (name: ${PREV_MANIFEST_NAME:-<none>})"
+
+    - name: Enrich manifest with changelog
+      run: |
+        set -e
+        NEW_MANIFEST=$(find ./songbooks -name '*.manifest.json' -print -quit)
+        if [ -z "$NEW_MANIFEST" ]; then
+          echo "No manifest file found in artifact."
+          exit 1
+        fi
+        uv run .github/scripts/compute-changelog.py \
+          "$NEW_MANIFEST" \
+          "${{ steps.fetch-previous.outputs.prev_manifest_path }}" \
+          "${{ steps.fetch-previous.outputs.prev_manifest_name }}"
+
     - name: Upload PDF to GCS
       id: upload-pdf
       run: |

--- a/generator/worker/pdf.py
+++ b/generator/worker/pdf.py
@@ -1271,6 +1271,10 @@ def generate_manifest(
 ) -> Dict[str, Any]:
     """Generate manifest data for a PDF generation job.
 
+    Note: the publish pipeline may inject an optional top-level ``changelog``
+    object (added/removed songs vs. the previously published edition) into the
+    manifest after generation. The worker itself does not compute it.
+
     Args:
         job_id: Unique identifier for the generation job
         params: Original job parameters


### PR DESCRIPTION
## Summary
This PR adds automatic changelog generation to the songbook publishing pipeline. When a new songbook edition is published, the manifest is now enriched with a `changelog` object that tracks which songs were added or removed compared to the previously published edition.

## Key Changes
- **New script: `compute-changelog.py`** – A pure utility script that diffs song lists between manifests and generates changelog metadata. It safely handles missing or corrupt previous manifests by degrading to empty changelogs (first-run behavior).
- **Comprehensive test suite: `test_compute_changelog.py`** – Tests cover basic add/remove detection, sorting, first-run scenarios, file I/O, and graceful degradation when previous manifests are unavailable.
- **Publishing workflow enhancement** – The `generate-songbook.yaml` workflow now:
  - Fetches the previously published manifest from GCS before uploading the new one
  - Runs the changelog computation script to enrich the manifest in place
  - Passes the previous manifest filename for proper attribution in the changelog
- **Documentation update** – Added a note to `pdf.py`'s `generate_manifest()` docstring clarifying that the changelog is injected by the publish pipeline, not computed by the worker.

## Implementation Details
- The changelog computation is a pure function that returns empty added/removed lists when there is no previous manifest (avoiding false "all songs added" reports on first publish).
- Song additions and removals are sorted alphabetically for consistent output.
- The workflow gracefully handles missing, corrupt, or absent previous manifests by logging a warning and writing an empty changelog rather than failing the build.
- The script uses `uv run` for dependency management and is compatible with Python 3.12+.

https://claude.ai/code/session_01HKST6T1xxz9fUWveQB96UL