### PR TITLE
Support {{NEXT_TUESDAY}} cover placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ title-font = "/usr/share/fonts/truetype/msttcorefonts/Verdana.ttf"
 title-fontsize = 16
 ```
 
+The cover Google Doc (configured via `[cover] file-id`) may contain text placeholders that are substituted at generation time and reverted afterwards:
+
+- `{{DATE}}` — the date the songbook is generated.
+- `{{NEXT_TUESDAY}}` — the date of the upcoming Tuesday, or the current day when generated on a Tuesday. This lets a songbook be published ahead of the session while still showing the correct session date.
+
 It's definitely not complete at this stage though and doesn't expose all possible config options.
 
 #### Cloud Functions Environment

--- a/generator/worker/cover.py
+++ b/generator/worker/cover.py
@@ -9,6 +9,17 @@ from .exceptions import CoverGenerationException
 from .gcp import get_credentials
 
 
+def _next_tuesday(when):
+    """Date of the upcoming Tuesday, or `when` itself if it is already a Tuesday.
+
+    This lets a cover be generated ahead of a session while still showing the
+    coming Tuesday's date.
+    """
+    # arrow/datetime weekday(): Monday=0, Tuesday=1, ... Sunday=6.
+    # Python's modulo keeps the shift non-negative: Mon=+1, Tue=+0, Wed=+6, Sun=+2.
+    return when.shift(days=(1 - when.weekday()) % 7)
+
+
 class CoverGenerator:
     def __init__(
         self,
@@ -25,18 +36,21 @@ class CoverGenerator:
     def _apply_template_replacements(self, document_id: str, replacement_map: dict):
         """
         Applies text replacements to a Google Doc.
-        If it fails, it logs an error and continues gracefully.
+
+        Returns a mapping of each placeholder to the number of occurrences that
+        were replaced (0 when the placeholder is absent). If the update fails, it
+        logs an error, continues gracefully, and returns an empty mapping.
         """
-        requests = []
-        for placeholder, new_text in replacement_map.items():
-            requests.append(
-                {
-                    "replaceAllText": {
-                        "containsText": {"text": placeholder, "matchCase": True},
-                        "replaceText": new_text,
-                    }
+        placeholders = list(replacement_map.keys())
+        requests = [
+            {
+                "replaceAllText": {
+                    "containsText": {"text": placeholder, "matchCase": True},
+                    "replaceText": replacement_map[placeholder],
                 }
-            )
+            }
+            for placeholder in placeholders
+        ]
 
         try:
             result = (
@@ -53,22 +67,21 @@ class CoverGenerator:
                 f"Error: {e}",
                 err=True,
             )
-            return
-        total = 0
+            return {}
+
+        # Replies are returned in the same order as the requests we sent.
         replies = result.get("replies", []) if isinstance(result, dict) else []
-        for reply in replies:
-            if reply is None:
+        counts = {placeholder: 0 for placeholder in placeholders}
+        for placeholder, reply in zip(placeholders, replies):
+            if not isinstance(reply, dict):
                 continue
-            try:
-                replace_all_text = reply.get("replaceAllText")
-                if replace_all_text is not None and isinstance(replace_all_text, dict):
-                    occurrences = replace_all_text.get("occurrencesChanged")
-                    if isinstance(occurrences, int):
-                        total += occurrences
-            except (KeyError, TypeError, AttributeError):
-                # Skip replies that have malformed structure
-                pass
-        click.echo(f"Replaced {total} occurrences in the copy.")
+            replace_all_text = reply.get("replaceAllText")
+            if isinstance(replace_all_text, dict):
+                occurrences = replace_all_text.get("occurrencesChanged")
+                if isinstance(occurrences, int):
+                    counts[placeholder] = occurrences
+        click.echo(f"Replaced {sum(counts.values())} occurrences in the copy.")
+        return counts
 
     def generate_cover(self, cover_file_id=None):
         if not cover_file_id:
@@ -79,9 +92,11 @@ class CoverGenerator:
 
         if self.enable_templating:
             today = arrow.now()
-            formatted_date = today.format("Do MMMM YYYY")
-            replacement_map = {"{{DATE}}": formatted_date}
-            self._apply_template_replacements(cover_file_id, replacement_map)
+            replacement_map = {
+                "{{DATE}}": today.format("Do MMMM YYYY"),
+                "{{NEXT_TUESDAY}}": _next_tuesday(today).format("Do MMMM YYYY"),
+            }
+            counts = self._apply_template_replacements(cover_file_id, replacement_map)
 
             try:
                 pdf_data = self.gdrive_client.download_file(
@@ -97,9 +112,19 @@ class CoverGenerator:
                     "Downloaded cover file is corrupted. Please check the file on Google Drive."
                 ) from e
             finally:
-                # Revert changes
-                revert_map = {v: k for k, v in replacement_map.items()}
-                self._apply_template_replacements(cover_file_id, revert_map)
+                # Revert only the placeholders that were actually present. On a
+                # Tuesday {{DATE}} and {{NEXT_TUESDAY}} format to the same string,
+                # so inverting the whole map would rewrite the source doc's
+                # {{DATE}} into {{NEXT_TUESDAY}} (or vice-versa). A cover uses one
+                # placeholder or the other, never both, so reverting the present
+                # ones restores the document exactly.
+                revert_map = {
+                    replacement_map[p]: p
+                    for p in replacement_map
+                    if counts.get(p, 0) > 0
+                }
+                if revert_map:
+                    self._apply_template_replacements(cover_file_id, revert_map)
         else:
             # No templating, just download the file
             pdf_data = self.gdrive_client.download_file(

--- a/generator/worker/test_cover.py
+++ b/generator/worker/test_cover.py
@@ -1,3 +1,5 @@
+import json
+import arrow
 import pytest
 from unittest.mock import Mock, patch
 import fitz
@@ -33,6 +35,7 @@ def test_generate_cover_with_templating(mock_apply_replacements, mock_download_f
     mock_gdrive_client = Mock(spec=cover.GoogleDriveClient)
     mock_docs = Mock()
     mock_download_file.return_value = b"fake-pdf-content"  # Fix for fitz.open
+    mock_apply_replacements.return_value = {"{{DATE}}": 1, "{{NEXT_TUESDAY}}": 1}
     mock_config = config.Cover(file_id="cover123")
 
     generator = cover.CoverGenerator(
@@ -166,6 +169,7 @@ def test_generate_cover_uses_provided_cover_id(
     mock_gdrive_client = Mock(spec=cover.GoogleDriveClient)
     mock_docs = Mock()
     mock_download_file.return_value = b"fake-pdf-content"
+    mock_apply_replacements.return_value = {"{{NEXT_TUESDAY}}": 1}
 
     generator = cover.CoverGenerator(
         mock_gdrive_client, mock_docs, mock_config, enable_templating=True
@@ -179,3 +183,87 @@ def test_generate_cover_uses_provided_cover_id(
     mock_gdrive_client.download_file.assert_called_once()
     called_kwargs = mock_gdrive_client.download_file.call_args[1]
     assert called_kwargs["file_id"] == "provided_cover_id"
+
+
+@pytest.mark.parametrize(
+    "today, expected",
+    [
+        ("2026-06-15", "2026-06-16"),  # Monday -> the coming Tuesday
+        ("2026-06-16", "2026-06-16"),  # Tuesday -> the same day
+        ("2026-06-17", "2026-06-23"),  # Wednesday -> the following Tuesday
+        ("2026-06-21", "2026-06-23"),  # Sunday -> the following Tuesday
+    ],
+)
+def test_next_tuesday(today, expected):
+    """_next_tuesday returns the upcoming Tuesday, or today if today is Tuesday."""
+    result = cover._next_tuesday(arrow.get(today))
+    assert result.format("YYYY-MM-DD") == expected
+
+
+@patch("generator.common.gdrive.GoogleDriveClient.download_file")
+@patch("generator.worker.cover.CoverGenerator._apply_template_replacements")
+@patch("generator.worker.cover.arrow.now")
+def test_generate_cover_templates_date_and_next_tuesday(
+    mock_now, mock_apply_replacements, mock_download_file
+):
+    """The forward replacement maps both {{DATE}} and {{NEXT_TUESDAY}}."""
+    # Monday 2026-06-15; the coming Tuesday is 2026-06-16.
+    mock_now.return_value = arrow.get("2026-06-15")
+    mock_apply_replacements.return_value = {"{{DATE}}": 1, "{{NEXT_TUESDAY}}": 1}
+    mock_download_file.return_value = b"fake-pdf-content"
+    mock_config = config.Cover(file_id="cover123")
+
+    generator = cover.CoverGenerator(
+        Mock(spec=cover.GoogleDriveClient),
+        Mock(),
+        mock_config,
+        enable_templating=True,
+    )
+    with patch("fitz.open"):
+        generator.generate_cover("cover123")
+
+    forward_map = mock_apply_replacements.call_args_list[0].args[1]
+    assert forward_map == {
+        "{{DATE}}": "15th June 2026",
+        "{{NEXT_TUESDAY}}": "16th June 2026",
+    }
+
+
+def test_apply_template_replacements_returns_counts():
+    """Returns per-placeholder occurrence counts from the batchUpdate replies."""
+    response_body = json.dumps(
+        {
+            "replies": [
+                {"replaceAllText": {"occurrencesChanged": 2}},
+                {"replaceAllText": {}},  # placeholder not present in the doc
+            ]
+        }
+    )
+    docs_http = HttpMockSequence([({"status": "200"}, response_body)])
+    docs = build("docs", "v1", http=docs_http)
+    generator = cover.CoverGenerator(
+        gdrive_client=Mock(spec=cover.GoogleDriveClient),
+        docs_service=docs,
+        cover_config=config.Cover(file_id="doc123"),
+    )
+
+    counts = generator._apply_template_replacements(
+        "doc123", {"{{DATE}}": "a", "{{NEXT_TUESDAY}}": "b"}
+    )
+
+    assert counts == {"{{DATE}}": 2, "{{NEXT_TUESDAY}}": 0}
+
+
+def test_apply_template_replacements_permission_error_returns_empty():
+    """A failed update returns an empty mapping so nothing is reverted."""
+    docs_http = HttpMockSequence([({"status": "403"}, "Permission denied")])
+    docs = build("docs", "v1", http=docs_http)
+    generator = cover.CoverGenerator(
+        gdrive_client=Mock(spec=cover.GoogleDriveClient),
+        docs_service=docs,
+        cover_config=config.Cover(file_id="doc123"),
+    )
+
+    counts = generator._apply_template_replacements("doc123", {"{{DATE}}": "value"})
+
+    assert counts == {}


### PR DESCRIPTION
## What

Adds a `{{NEXT_TUESDAY}}` placeholder for the cover Google Doc, alongside the existing `{{DATE}}`. It renders the date of the upcoming Tuesday (or the current day when generated *on* a Tuesday), so a songbook can be published ahead of the session while the cover still shows the correct session date.

Closes #378.

## Why

Today the cover only supports `{{DATE}}`, which is replaced with the generation day's date (`arrow.now()`). That means the songbook has to be generated on the session day for the cover to be correct — you can't publish in advance for the upcoming Tuesday.

## Changes

- **`generator/worker/cover.py`**
  - New `_next_tuesday(when)` helper: returns the upcoming Tuesday, or `when` itself if it's already a Tuesday. Uses `weekday()` + `arrow.shift`, no new dependencies.
  - `generate_cover` now templates both `{{DATE}}` and `{{NEXT_TUESDAY}}` (same `Do MMMM YYYY` format).
  - **Revert safety:** `_apply_template_replacements` now returns per-placeholder occurrence counts, and the revert only restores placeholders that were actually present. On a Tuesday both placeholders format to the *same* string, so the previous naive `{value: placeholder}` inversion would have rewritten the source doc's `{{DATE}}` into `{{NEXT_TUESDAY}}`. A cover uses one placeholder or the other, so reverting only the present ones restores the doc exactly.
- **`generator/worker/test_cover.py`** — parametrized `_next_tuesday` tests (Mon/Tue/Wed/Sun), a test asserting both placeholders are templated with the right dates, tests for the new counts return value (success + permission-error → `{}`), and updates to the two tests that mock `_apply_template_replacements`.
- **`README.md`** — documents the supported cover placeholders.

## Follow-up (not in this PR)

To actually use the new behaviour, the cover Google Doc template needs to be edited to use `{{NEXT_TUESDAY}}` (the template lives in Drive, outside this repo).

## Testing

- `uv run pytest generator/worker/test_cover.py -q` → 14 passed
- `uv run pytest -q` → 507 passed
- `ruff check` / `ruff format --check` clean

https://claude.ai/code/session_01Ehdgqm195YF2jwDyUrUiWh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ehdgqm195YF2jwDyUrUiWh)_