### PR TITLE
Add native PDF outline (bookmarks) to generated songbooks (fixes #2)

### DIFF
--- a/generator/worker/pdf.py
+++ b/generator/worker/pdf.py
@@ -1105,6 +1105,12 @@ def generate_songbook(
                             songbook_pdf, toc_entries, toc_start_page
                         )
 
+                # Set a native PDF outline (bookmarks) so readers show a
+                # navigable song sidebar indexed by page.
+                with reporter.step(1, "Adding PDF bookmarks..."):
+                    with tracer.start_as_current_span("set_pdf_outline"):
+                        toc.set_pdf_outline(songbook_pdf, toc_entries, toc_start_page)
+
                 with reporter.step(1, "Setting PDF metadata..."):
                     with tracer.start_as_current_span("set_metadata"):
                         metadata = {

--- a/generator/worker/test_toc.py
+++ b/generator/worker/test_toc.py
@@ -354,3 +354,115 @@ def test_build_table_of_contents_calls_assign_difficulty_bins(mocker):
     toc.build_table_of_contents(files)
 
     mock_assign_bins.assert_called_once_with(files)
+
+
+def _toc_entry(target_page, toc_page_index, title, text="display"):
+    """Build a TocEntry for outline tests (geometry is irrelevant here)."""
+    return toc.TocEntry(
+        page_number=target_page + 1,
+        target_page=target_page,
+        text=text,
+        rect=fitz.Rect(0, 0, 10, 10),
+        toc_page_index=toc_page_index,
+        title=title,
+    )
+
+
+def test_add_toc_entry_stores_full_title_for_outline(mock_toc_generator):
+    """The full, untruncated song name is kept for bookmarks even when the
+    displayed TOC text is shortened."""
+    generator = mock_toc_generator
+    generator.config.max_toc_entry_length = 20
+    mock_tw = MagicMock(spec=fitz.TextWriter)
+
+    long_name = "A Really Quite Long Song Title - The Artist Band"
+    generator._add_toc_entry(
+        tw=mock_tw,
+        file_index=3,
+        page_offset=10,
+        file=File(id="1", name=long_name),
+        x_start=25,
+        y_pos=70,
+        current_page_index=0,
+    )
+
+    entry = generator.get_toc_entries()[-1]
+    assert entry.title == long_name  # full title preserved
+    assert len(entry.text) < len(long_name)  # displayed text truncated
+    assert entry.target_page == 3
+    assert entry.page_number == 14  # file_index + 1 + page_offset
+
+
+def test_build_pdf_outline_page_math_and_titles():
+    """Outline pages are 1-based and account for cover/preface + TOC pages."""
+    entries = [
+        _toc_entry(0, 0, "Song A - Artist"),
+        _toc_entry(1, 0, "Song B - Artist"),
+        _toc_entry(2, 1, ""),  # empty title falls back to display text
+    ]
+    entries[2].text = "Song C short"
+
+    # toc_page_offset=2 (cover+preface), 2 distinct TOC pages -> songs start at
+    # 0-based index 4, so 1-based pages 5, 6, 7.
+    outline = toc.build_pdf_outline(entries, toc_page_offset=2)
+    assert outline == [
+        [1, "Song A - Artist", 5],
+        [1, "Song B - Artist", 6],
+        [1, "Song C short", 7],
+    ]
+
+
+def test_build_pdf_outline_skips_out_of_range_pages():
+    entries = [_toc_entry(i, 0, f"Song {i}") for i in range(3)]
+    # 1 TOC page, offset 2 -> 0-based targets 3, 4, 5. page_count=5 drops the last.
+    outline = toc.build_pdf_outline(entries, toc_page_offset=2, page_count=5)
+    assert [o[2] for o in outline] == [4, 5]
+
+
+def test_build_pdf_outline_skips_empty_titles():
+    entry = _toc_entry(0, 0, "", text="")
+    assert toc.build_pdf_outline([entry], toc_page_offset=0) == []
+
+
+def test_set_pdf_outline_sets_bookmarks_on_document():
+    doc = fitz.open()
+    for _ in range(8):
+        doc.new_page()
+    entries = [
+        _toc_entry(0, 0, "Song A - Artist"),
+        _toc_entry(1, 0, "Song B - Artist"),
+    ]
+    # offset 1 (cover) + 1 TOC page -> 0-based targets 2, 3 -> 1-based pages 3, 4.
+    applied = toc.set_pdf_outline(doc, entries, toc_page_offset=1)
+    expected = [[1, "Song A - Artist", 3], [1, "Song B - Artist", 4]]
+    assert applied == expected
+    assert doc.get_toc() == expected
+    doc.close()
+
+
+def test_set_pdf_outline_no_entries_is_noop():
+    doc = fitz.open()
+    doc.new_page()
+    assert toc.set_pdf_outline(doc, [], toc_page_offset=0) == []
+    assert doc.get_toc() == []
+    doc.close()
+
+
+def test_outline_and_links_resolve_to_the_same_pages():
+    """Bookmarks and clickable TOC links must point at identical pages."""
+    doc = fitz.open()
+    for _ in range(10):
+        doc.new_page()
+    entries = [_toc_entry(i, 0, f"Song {i}") for i in range(3)]
+    toc_page_offset = 2  # cover + preface
+
+    toc.add_toc_links_to_merged_pdf(doc, entries, toc_page_offset)
+    outline = toc.set_pdf_outline(doc, entries, toc_page_offset)
+
+    toc_page = doc[toc_page_offset]  # all entries are on the first TOC page
+    link_pages = sorted(
+        ln["page"] for ln in toc_page.get_links() if ln.get("kind") == fitz.LINK_GOTO
+    )
+    outline_pages = sorted(o[2] - 1 for o in outline)  # 1-based -> 0-based
+    assert link_pages == outline_pages == [3, 4, 5]
+    doc.close()

--- a/generator/worker/toc.py
+++ b/generator/worker/toc.py
@@ -35,6 +35,8 @@ class TocEntry:
     text: str
     rect: fitz.Rect
     toc_page_index: int
+    title: str = ""
+    """Full, untruncated song title, used for the native PDF outline/bookmarks."""
 
 
 class TocGenerator:
@@ -168,6 +170,7 @@ class TocGenerator:
                 text=shortened_title,
                 rect=link_rect,
                 toc_page_index=current_page_index,
+                title=file.name,
             )
         )
 
@@ -291,6 +294,62 @@ def build_table_of_contents(
         return toc_pdf, generator.get_toc_entries()
 
 
+def _target_page_index(
+    toc_entries: List[TocEntry], entry: TocEntry, toc_page_offset: int
+) -> int:
+    """Absolute 0-based index of an entry's song page in the merged PDF.
+
+    Songs sit immediately after the cover/preface (``toc_page_offset``) and the
+    TOC pages, hence ``+ number of TOC pages + the file's index``. This is the
+    same arithmetic used to place the clickable TOC links, so bookmarks and
+    links always resolve to the same page.
+    """
+    num_toc_pages = len({e.toc_page_index for e in toc_entries})
+    return toc_page_offset + num_toc_pages + entry.target_page
+
+
+def build_pdf_outline(
+    toc_entries: List[TocEntry],
+    toc_page_offset: int,
+    page_count: Optional[int] = None,
+) -> List[list]:
+    """Build a PyMuPDF outline (``[[level, title, page], ...]``) from TOC entries.
+
+    Pages are 1-based, as required by :meth:`fitz.Document.set_toc`. When
+    ``page_count`` is given, entries whose target page falls outside the document
+    are skipped (mirrors the bounds check used when inserting TOC links).
+    """
+    outline: List[list] = []
+    for entry in toc_entries:
+        target_page_index = _target_page_index(toc_entries, entry, toc_page_offset)
+        if page_count is not None and target_page_index >= page_count:
+            continue
+        title = entry.title or entry.text
+        if not title:
+            continue
+        outline.append([1, title, target_page_index + 1])
+    return outline
+
+
+def set_pdf_outline(
+    merged_pdf: fitz.Document, toc_entries: List[TocEntry], toc_page_offset: int
+) -> List[list]:
+    """Set a native PDF outline (bookmarks) on the merged PDF from TOC entries.
+
+    One top-level bookmark per song pointing at its page, so PDF readers show a
+    navigable sidebar. Returns the outline that was applied (empty if there were
+    no entries).
+    """
+    with tracer.start_as_current_span("set_pdf_outline") as span:
+        outline = build_pdf_outline(
+            toc_entries, toc_page_offset, page_count=len(merged_pdf)
+        )
+        span.set_attribute("toc.outline.count", len(outline))
+        if outline:
+            merged_pdf.set_toc(outline)
+        return outline
+
+
 def add_toc_links_to_merged_pdf(
     merged_pdf: fitz.Document, toc_entries: List[TocEntry], toc_page_offset: int
 ):
@@ -312,13 +371,9 @@ def add_toc_links_to_merged_pdf(
 
             toc_page = merged_pdf[toc_page_index]
 
-            # Calculate the target page in the merged PDF
-            # The target page is after all TOC pages plus the file's index
-            target_page_index = (
-                toc_page_offset
-                + len({e.toc_page_index for e in toc_entries})
-                + entry.target_page
-            )
+            # Calculate the target page in the merged PDF (shared with the native
+            # outline so links and bookmarks always point to the same page).
+            target_page_index = _target_page_index(toc_entries, entry, toc_page_offset)
             if target_page_index >= len(merged_pdf):
                 continue
 


### PR DESCRIPTION
## Fixes #2 — Proper PDF style TOC support

The OG issue, finally retired. 😄 The worker rendered a **TOC page** and added **clickable links**, but never called `set_toc()`, so generated edition PDFs shipped with **no native outline/bookmarks** — the manifest even recorded `has_toc: false`, `toc_entries: 0`. PDF readers showed no navigable song sidebar.

### What this does

Adds a one-bookmark-per-song native outline pointing at each song's page, so readers show a navigable sidebar indexed by page.

- **`generator/worker/toc.py`**
  - `build_pdf_outline()` (pure) and `set_pdf_outline()` turn the existing `toc_entries` into a `[[1, title, page], …]` outline and apply it with `Document.set_toc`.
  - Page math is extracted into a shared `_target_page_index()` and reused by the existing `add_toc_links_to_merged_pdf`, so **links and bookmarks can never drift apart**.
  - `TocEntry` now carries the **full, untruncated song title** for clean bookmark labels (the on-page TOC text stays shortened as before).
- **`generator/worker/pdf.py`** — calls `set_pdf_outline()` right after the TOC links step. The manifest's `has_toc` / `toc_entries` (computed via `get_toc()`) now populate automatically, and the existing `validate-pdf` TOC checks start asserting the outline is present.

### Tests

`generator/worker/test_toc.py` adds: page arithmetic, out-of-range/empty-title handling, real-document `set_toc` round-trip, full-title-vs-truncated-display, and a **link/bookmark consistency** check (both resolve to identical pages). Full worker + validation suites pass (144); `ruff check .` clean.

Verified end-to-end with real fonts — a 4-song book produces bookmarks `p4..p7` with full titles, songs correctly starting after cover+preface+TOC.

### Notes

- Scope is the per-edition worker path. The `complete` songbook already set an outline via `cache_updater`; this brings every edition (`current`, etc.) in line.
- No config/schema changes; purely additive to the generated PDF.

https://claude.ai/code/session_014Rx5yvSkbY3H3TF2e45mVi

---
_Generated by [Claude Code](https://claude.ai/code/session_014Rx5yvSkbY3H3TF2e45mVi)_