### PR TITLE
Backfill changelog from TOC page text for historical editions (closes #381)

### DIFF
--- a/generator/changelog.py
+++ b/generator/changelog.py
@@ -19,6 +19,8 @@ handles reading/writing files and the publish pipeline handles GCS transfer.
 
 from typing import Any, Optional
 
+from .common.titles import generate_short_title
+
 DEFAULT_MAX_ENTRIES = 50
 
 
@@ -113,6 +115,73 @@ def update_history(
     entries.insert(0, entry)
     history["entries"] = entries[:max_entries]
     return history
+
+
+def short_key(raw: str, max_length: Optional[int] = None) -> str:
+    """Canonical, comparison-friendly form of a song title.
+
+    Runs the title through the same deterministic shortener the TOC uses
+    (:func:`generate_short_title`) and casefolds it, so a manifest's full
+    ``file_names`` entry and the (already shortened) title parsed from a rendered
+    TOC page collapse to the same key. This is what lets the changelog diff span
+    the manifest era and the TOC-reconstructed era without spurious churn.
+    """
+    title = generate_short_title(raw or "", max_length=max_length)
+    if title.endswith("*"):
+        title = title[:-1].rstrip()
+    return title.casefold()
+
+
+def diff_keyed(new: dict[str, str], old: dict[str, str]) -> tuple[list[str], list[str]]:
+    """Diff two ``{key: label}`` song maps, returning sorted added/removed labels.
+
+    Comparison is on the canonical keys; the human-readable labels come from the
+    side that holds the song (added → ``new``, removed → ``old``), so recent
+    entries keep full names while historical ones use the shortened TOC titles.
+    """
+    added_keys, removed_keys = diff_songs(list(new), list(old))
+    added = sorted(new[k] for k in added_keys)
+    removed = sorted(old[k] for k in removed_keys)
+    return added, removed
+
+
+def build_timeline(
+    publishes: list[dict[str, Any]],
+    edition: str,
+    max_entries: int = DEFAULT_MAX_ENTRIES,
+) -> dict[str, Any]:
+    """Build a full ``changes.json`` from a list of publishes (newest first).
+
+    Each publish is ``{"date", "source", "filename", "songs": {key: label}}``.
+    Publishes are ordered by date, consecutive song sets are diffed (empty diffs
+    skipped), and each recorded entry is tagged with its ``source``
+    (``"manifest"`` or ``"toc-page"``). Unlike :func:`update_history` (which
+    merges one new publish at a time), this rebuilds the whole history at once.
+    """
+    pubs = sorted(publishes, key=lambda p: p["date"])
+    entries: list[dict[str, Any]] = []
+    previous: Optional[dict[str, Any]] = None
+    for pub in pubs:
+        if previous is not None:
+            added, removed = diff_keyed(pub["songs"], previous["songs"])
+            if added or removed:
+                entries.append(
+                    {
+                        "generated_at": pub.get("generated_at", pub["date"]),
+                        "date": pub["date"],
+                        "source": pub["source"],
+                        "filename": pub["filename"],
+                        "previous_filename": previous["filename"],
+                        "previous_date": previous["date"],
+                        "added": added,
+                        "removed": removed,
+                        "added_count": len(added),
+                        "removed_count": len(removed),
+                    }
+                )
+        previous = pub
+    entries.reverse()  # newest first
+    return {"edition": edition, "entries": entries[:max_entries]}
 
 
 def backfill_history(

--- a/generator/cli/__init__.py
+++ b/generator/cli/__init__.py
@@ -8,7 +8,11 @@ import logging
 import click
 
 from .cache import cache
-from .changelog import backfill_changelog, update_changelog
+from .changelog import (
+    backfill_changelog,
+    backfill_changelog_from_pdfs,
+    update_changelog,
+)
 from .editions import editions
 from .generate import generate
 from .misc import print_settings, validate_pdf_cli
@@ -42,6 +46,7 @@ cli.add_command(editions)
 cli.add_command(tags)
 cli.add_command(update_changelog)
 cli.add_command(backfill_changelog)
+cli.add_command(backfill_changelog_from_pdfs)
 
 if __name__ == "__main__":
     cli()

--- a/generator/cli/changelog.py
+++ b/generator/cli/changelog.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -9,10 +10,25 @@ from ..changelog import (
     DEFAULT_MAX_ENTRIES,
     backfill_history,
     build_entry,
+    build_timeline,
     empty_history,
+    short_key,
     update_history,
 )
 from .utils import global_options
+
+# ukulele-tuesday-songbook-<edition>-YYYY-MM-DD(.pdf | .manifest.json)
+# Edition ids can contain hyphens, so the date anchors the split.
+_NAME_RE = re.compile(
+    r"^ukulele-tuesday-songbook-(?P<edition>.+)-(?P<date>\d{4}-\d{2}-\d{2})"
+    r"\.(?:pdf|manifest\.json)$"
+)
+
+
+def _parse_edition_date(filename: str) -> Optional[tuple[str, str]]:
+    """Return ``(edition, YYYY-MM-DD)`` parsed from a songbook filename, or None."""
+    m = _NAME_RE.match(filename)
+    return (m.group("edition"), m.group("date")) if m else None
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -188,5 +204,137 @@ def backfill_changelog(
     )
 
 
+@click.command(name="backfill-changelog-from-pdfs")
+@global_options
+@click.option(
+    "--pdfs-dir",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Directory of historical *.pdf songbooks (any path scheme, flat).",
+)
+@click.option(
+    "--manifests-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Optional directory of *.manifest.json (preferred over PDFs per date; "
+    "gives full-name labels for the manifest era).",
+)
+@click.option("--edition", required=True, help="Edition id, e.g. 'current'.")
+@click.option(
+    "--max-title-length",
+    type=int,
+    default=None,
+    help="TOC max title length used for canonical matching "
+    "(defaults to the configured Toc.max_toc_entry_length).",
+)
+@click.option(
+    "--output",
+    type=click.Path(path_type=Path),
+    default=Path("changes.json"),
+    help="Where to write the rebuilt changes.json.",
+)
+@click.option(
+    "--max-entries",
+    type=int,
+    default=DEFAULT_MAX_ENTRIES,
+    help="Maximum number of history entries to keep.",
+)
+def backfill_changelog_from_pdfs(
+    pdfs_dir: Path,
+    manifests_dir: Optional[Path],
+    edition: str,
+    max_title_length: Optional[int],
+    output: Path,
+    max_entries: int,
+    **kwargs,
+):
+    """Rebuild a full changes.json from historical PDFs (and optional manifests).
+
+    For dates that predate the JSON manifest, the song list is reconstructed from
+    the rendered Table-of-Contents page text; for the manifest era, the manifest
+    is used (preferred per date) so recent entries keep full song names. Both are
+    matched on a canonical shortened-title key so the eras stitch together
+    cleanly. Filenames must follow ``ukulele-tuesday-songbook-<edition>-DATE.*``.
+    """
+    # Lazy imports: fitz / settings are heavy and only needed here.
+    import fitz
+
+    from ..common.config import get_settings
+    from ..toc_parse import parse_toc_songs
+
+    max_len = (
+        max_title_length
+        if max_title_length is not None
+        else get_settings().toc.max_toc_entry_length
+    )
+
+    # date -> publish record; manifests win over PDFs for the same date.
+    publishes: dict[str, dict[str, Any]] = {}
+
+    if manifests_dir:
+        for path in sorted(manifests_dir.glob("*.manifest.json")):
+            parsed = _parse_edition_date(path.name)
+            try:
+                manifest = _load_json(path)
+            except (OSError, ValueError) as e:
+                click.echo(f"Skipping unreadable manifest {path}: {e}", err=True)
+                continue
+            ed = (manifest.get("edition") or {}).get("id") or (
+                parsed[0] if parsed else None
+            )
+            if ed != edition or not parsed:
+                continue
+            names = manifest.get("content_info", {}).get("file_names") or []
+            publishes[parsed[1]] = {
+                "date": parsed[1],
+                "generated_at": manifest.get("generated_at", parsed[1]),
+                "source": "manifest",
+                "filename": path.name,
+                "songs": {short_key(n, max_len): n for n in names},
+            }
+
+    for path in sorted(pdfs_dir.glob("*.pdf")):
+        parsed = _parse_edition_date(path.name)
+        if not parsed or parsed[0] != edition:
+            continue
+        date = parsed[1]
+        if date in publishes:  # a manifest already covers this date
+            continue
+        try:
+            with fitz.open(path) as doc:
+                titles = parse_toc_songs(doc)
+        except Exception as e:  # noqa: BLE001 - skip a single bad PDF, keep going
+            click.echo(f"Skipping unreadable PDF {path}: {e}", err=True)
+            continue
+        if not titles:
+            click.echo(f"No TOC songs parsed from {path.name}; skipping.", err=True)
+            continue
+        publishes[date] = {
+            "date": date,
+            "generated_at": date,
+            "source": "toc-page",
+            "filename": path.name,
+            "songs": {short_key(t, max_len): t for t in titles},
+        }
+
+    if not publishes:
+        click.echo(f"No publishes found for edition '{edition}'.", err=True)
+        sys.exit(1)
+
+    history = build_timeline(list(publishes.values()), edition, max_entries)
+    output.write_text(json.dumps(history, indent=2), encoding="utf-8")
+    n_manifest = sum(1 for p in publishes.values() if p["source"] == "manifest")
+    n_toc = len(publishes) - n_manifest
+    click.echo(
+        f"✅ Backfilled {len(history['entries'])} changelog entries for "
+        f"'{edition}' from {len(publishes)} publishes "
+        f"({n_manifest} manifest, {n_toc} toc-page) -> {output}"
+    )
+
+
 # Convenience for callers that want an empty starting point.
-__all__ = ["update_changelog", "backfill_changelog", "empty_history"]
+__all__ = [
+    "update_changelog",
+    "backfill_changelog",
+    "backfill_changelog_from_pdfs",
+    "empty_history",
+]

--- a/generator/cli/test_changelog.py
+++ b/generator/cli/test_changelog.py
@@ -1,9 +1,12 @@
 import json
 
+import fitz
 import pytest
 from click.testing import CliRunner
 
 from ..cli import cli
+from ..worker import toc as tocmod
+from ..worker.models import File
 
 
 @pytest.fixture
@@ -170,3 +173,62 @@ def test_backfill_changelog_builds_history(runner, tmp_path):
     ]
     assert history["entries"][0]["added"] == ["C"]
     assert history["entries"][0]["removed"] == ["B"]
+
+
+def _write_songbook_pdf(path, names, cover_preface=2):
+    """Render a real TOC and assemble a songbook-like PDF on disk."""
+    files = [File(id=str(i), name=n) for i, n in enumerate(names)]
+    tp, _ = tocmod.build_table_of_contents(files, 0)
+    offset = cover_preface + len(tp)
+    tp.close()
+    tp, _ = tocmod.build_table_of_contents(files, offset)
+    doc = fitz.open()
+    for _ in range(cover_preface):
+        doc.new_page()
+    doc.insert_pdf(tp)
+    for _ in files:
+        doc.new_page()
+    doc.save(str(path))
+    doc.close()
+
+
+def test_backfill_changelog_from_pdfs_builds_full_history(runner, tmp_path):
+    pdfs = tmp_path / "pdfs"
+    pdfs.mkdir()
+    # Two historical (pre-manifest) publishes with a real song change between them.
+    _write_songbook_pdf(
+        pdfs / "ukulele-tuesday-songbook-current-2025-09-27.pdf",
+        ["Angels - Robbie Williams", "Jolene - Dolly Parton"],
+    )
+    _write_songbook_pdf(
+        pdfs / "ukulele-tuesday-songbook-current-2025-10-04.pdf",
+        ["Angels - Robbie Williams", "Hey Jude - The Beatles"],
+    )
+    # A stray different-edition PDF that must be ignored.
+    _write_songbook_pdf(
+        pdfs / "ukulele-tuesday-songbook-complete-2025-10-04.pdf",
+        ["Some Other Song - Nobody"],
+    )
+    out = tmp_path / "changes.json"
+
+    result = runner.invoke(
+        cli,
+        [
+            "backfill-changelog-from-pdfs",
+            "--pdfs-dir",
+            str(pdfs),
+            "--edition",
+            "current",
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    history = json.loads(out.read_text())
+    assert history["edition"] == "current"
+    assert len(history["entries"]) == 1
+    entry = history["entries"][0]
+    assert entry["date"] == "2025-10-04"
+    assert entry["source"] == "toc-page"
+    assert entry["added"] == ["Hey Jude - The Beatles"]
+    assert entry["removed"] == ["Jolene - Dolly Parton"]

--- a/generator/test_changelog.py
+++ b/generator/test_changelog.py
@@ -1,9 +1,12 @@
 from .changelog import (
     backfill_history,
     build_entry,
+    build_timeline,
+    diff_keyed,
     diff_songs,
     empty_history,
     load_file_names,
+    short_key,
     update_history,
 )
 
@@ -118,6 +121,59 @@ def test_update_history_starts_fresh_when_existing_none():
     history = update_history(None, {"manifest_filename": "m.json"}, "current")
     assert history["edition"] == "current"
     assert len(history["entries"]) == 1
+
+
+def test_short_key_matches_full_and_shortened_titles():
+    # Full manifest name and its TOC-shortened render collapse to one key.
+    full = "Crocodile Rock (Radio Edit) - Elton John"
+    rendered = "Crocodile Rock - Elton John"  # as the TOC would show it
+    assert short_key(full, max_length=52) == short_key(rendered, max_length=52)
+
+
+def test_short_key_casefolds_and_strips_marker():
+    assert short_key("Hey Jude - The Beatles*") == short_key("hey jude - the beatles")
+
+
+def test_diff_keyed_uses_keys_but_returns_labels():
+    new = {"a": "Song A - Artist", "b": "Song B - Artist"}
+    old = {"a": "Song A - Artist", "c": "Song C - Artist"}
+    added, removed = diff_keyed(new, old)
+    assert added == ["Song B - Artist"]
+    assert removed == ["Song C - Artist"]
+
+
+def _pub(date, source, filename, songs):
+    return {"date": date, "source": source, "filename": filename, "songs": songs}
+
+
+def test_build_timeline_orders_diffs_and_tags_source():
+    publishes = [
+        _pub("2025-09-27", "toc-page", "old.pdf", {"a": "A - X", "b": "B - Y"}),
+        # New era, same two songs but full-name labels -> no spurious diff.
+        _pub("2026-02-06", "manifest", "m1.json", {"a": "A - X (Mono)", "b": "B - Y"}),
+        _pub("2026-06-09", "manifest", "m2.json", {"a": "A - X (Mono)", "c": "C - Z"}),
+    ]
+    history = build_timeline(publishes, "current")
+    assert history["edition"] == "current"
+    # Only the 09-27->02-06 boundary is a no-op; one real change recorded.
+    assert len(history["entries"]) == 1
+    entry = history["entries"][0]
+    assert entry["date"] == "2026-06-09"
+    assert entry["source"] == "manifest"
+    assert entry["added"] == ["C - Z"]
+    assert entry["removed"] == ["B - Y"]
+    assert entry["previous_filename"] == "m1.json"
+
+
+def test_build_timeline_newest_first_and_capped():
+    publishes = [
+        _pub("2026-01-01", "toc-page", "p0.pdf", {"a": "A - X"}),
+        _pub("2026-01-02", "toc-page", "p1.pdf", {"a": "A - X", "b": "B - Y"}),
+        _pub("2026-01-03", "toc-page", "p2.pdf", {"b": "B - Y"}),
+    ]
+    history = build_timeline(publishes, "current", max_entries=1)
+    assert len(history["entries"]) == 1
+    assert history["entries"][0]["date"] == "2026-01-03"  # newest kept
 
 
 def test_backfill_history_filters_sorts_and_diffs():

--- a/generator/test_toc_parse.py
+++ b/generator/test_toc_parse.py
@@ -1,0 +1,137 @@
+import fitz
+
+from . import toc_parse
+from .changelog import short_key
+from .worker import toc
+from .worker.models import File
+
+
+def test_extract_glyph_lines_strips_glyph_marker_and_page_numbers():
+    lines = [
+        "Table of Contents",
+        "◕ 9 to 5 - Dolly Parton",
+        "4",
+        "..............................",
+        "○ All The Small Things - Blink-182",
+        "8",
+        "◔ Ready Song - Artist*",  # WIP marker stripped
+        "12",
+    ]
+    songs = toc_parse.extract_songs_from_lines(lines, postfixes=[])
+    assert songs == [
+        "9 to 5 - Dolly Parton",
+        "All The Small Things - Blink-182",
+        "Ready Song - Artist",
+    ]
+
+
+def test_extract_strips_configured_postfix_and_marker_any_order():
+    lines = ["◕ Monster Mash - Bobby Pickett 🎃", "● Spooky - Artist*🎃"]
+    songs = toc_parse.extract_songs_from_lines(lines, postfixes=["🎃"])
+    assert songs == ["Monster Mash - Bobby Pickett", "Spooky - Artist"]
+
+
+def test_extract_strips_unknown_trailing_emoji_marker():
+    # Historical editions appended themed emoji we have no config for.
+    lines = ["◕ Hotel California - The Eagles 🎻", "● Creep - Radiohead 🎸️"]
+    songs = toc_parse.extract_songs_from_lines(lines, postfixes=[])
+    assert songs == ["Hotel California - The Eagles", "Creep - Radiohead"]
+
+
+def test_extract_strips_themed_letter_postfix_token():
+    # A real case: a themed postfix rendered as a Greek-letter glyph (U+1F33),
+    # which is a *letter* category, not a symbol — must still be stripped.
+    lines = ["◕ Creep - Radiohead* ἳ", "◔ Candy - Paolo Nutini ἳ"]
+    songs = toc_parse.extract_songs_from_lines(lines, postfixes=[])
+    assert songs == ["Creep - Radiohead", "Candy - Paolo Nutini"]
+
+
+def test_extract_keeps_real_non_ascii_words():
+    # Don't eat legitimate accented/foreign title words.
+    lines = ["○ Ça plan pour moi - Plastic Bertrand", "○ 99 Luftballons - Nena"]
+    songs = toc_parse.extract_songs_from_lines(lines, postfixes=[])
+    assert songs == ["Ça plan pour moi - Plastic Bertrand", "99 Luftballons - Nena"]
+
+
+def test_extract_dash_fallback_when_no_glyphs():
+    lines = [
+        "Table of Contents",
+        "Wonderwall - Oasis",
+        "5",
+        "Imagine - John Lennon",
+        "6",
+    ]
+    songs = toc_parse.extract_songs_from_lines(lines, postfixes=[])
+    assert songs == ["Wonderwall - Oasis", "Imagine - John Lennon"]
+
+
+def test_extract_dedupes_preserving_order():
+    lines = ["○ A - X", "○ B - Y", "○ A - X"]
+    assert toc_parse.extract_songs_from_lines(lines, postfixes=[]) == ["A - X", "B - Y"]
+
+
+def test_find_toc_pages_uses_page_indices():
+    doc = fitz.open()
+    for _ in range(5):
+        doc.new_page()
+    pages = toc_parse.find_toc_pages(
+        doc, page_indices={"table_of_contents": {"first_page": 3, "last_page": 4}}
+    )
+    assert pages == [2, 3]
+    doc.close()
+
+
+def _assemble_songbook(files, cover_preface=2):
+    """Render a real TOC via the production generator and assemble a doc that
+    looks like a songbook (cover/preface + TOC pages + one page per song)."""
+    tp, _ = toc.build_table_of_contents(files, 0)
+    page_offset = cover_preface + len(tp)
+    tp.close()
+    tp, _ = toc.build_table_of_contents(files, page_offset)
+    doc = fitz.open()
+    for _ in range(cover_preface):
+        doc.new_page()
+    toc_start = len(doc)
+    doc.insert_pdf(tp)
+    toc_pages = len(doc) - toc_start
+    for _ in files:
+        doc.new_page()
+    page_indices = {
+        "table_of_contents": {
+            "first_page": toc_start + 1,
+            "last_page": toc_start + toc_pages,
+        }
+    }
+    return doc, page_indices
+
+
+def test_parse_toc_songs_roundtrip_recovers_all_songs():
+    """The parser recovers exactly the songs the real TOC generator rendered."""
+    names = [
+        "9 to 5 - Dolly Parton",
+        "Crocodile Rock - Elton John",
+        "I Want to Break Free - Queen",
+        "(You're the) Devil in Disguise - Elvis Presley",
+        "Wonderwall - Oasis",
+    ]
+    files = [File(id=str(i), name=n) for i, n in enumerate(names)]
+    doc, page_indices = _assemble_songbook(files)
+
+    parsed = toc_parse.parse_toc_songs(doc, page_indices=page_indices)
+    assert {short_key(p) for p in parsed} == {short_key(n) for n in names}
+    doc.close()
+
+
+def test_parse_toc_songs_roundtrip_without_page_indices():
+    """Heuristic page detection finds the TOC when no manifest page_indices."""
+    names = [
+        "Angels - Robbie Williams",
+        "Jolene - Dolly Parton",
+        "Hey Jude - The Beatles",
+    ]
+    files = [File(id=str(i), name=n) for i, n in enumerate(names)]
+    doc, _ = _assemble_songbook(files)
+
+    parsed = toc_parse.parse_toc_songs(doc)  # no page_indices -> heuristic
+    assert {short_key(p) for p in parsed} == {short_key(n) for n in names}
+    doc.close()

--- a/generator/toc_parse.py
+++ b/generator/toc_parse.py
@@ -1,0 +1,137 @@
+"""Reconstruct an edition's song list from a generated PDF's Table of Contents.
+
+Historical songbooks predate the JSON manifest (and carry no native PDF outline),
+so their song list can only be recovered from the *rendered* TOC page text. Each
+TOC entry reads ``<difficulty glyph> <short title><optional marker><postfix>``
+followed by a page number on the next line. We only need the *set* of titles, so
+ordering and page numbers are ignored — which also sidesteps multi-column
+text-extraction ordering quirks.
+"""
+
+import logging
+import re
+import unicodedata
+from typing import Any, Optional
+
+import fitz
+
+from .common.config import get_settings
+from .worker.toc import difficulty_symbol
+
+# Unicode categories for trailing "marker" characters to strip from a TOC entry:
+# symbols/emoji (So, Sk) and format joiners / variation selectors (Cf). Song
+# titles never legitimately end in these, but historical editions appended
+# themed postfixes we don't have config for, so strip them generically.
+_MARKER_CATEGORIES = {"So", "Sk", "Cf"}
+_ASCII_ALNUM = re.compile(r"[A-Za-z0-9]")
+
+logger = logging.getLogger(__name__)
+
+# Glyphs that prefix every TOC entry (difficulty bins 1-5); see difficulty_symbol.
+DIFFICULTY_GLYPHS = "".join(difficulty_symbol(b) for b in range(1, 6))
+_HEADER = "table of contents"
+
+
+def find_toc_pages(
+    doc: "fitz.Document",
+    page_indices: Optional[dict[str, Any]] = None,
+    scan_pages: int = 10,
+) -> list[int]:
+    """Return the 0-based indices of the PDF's TOC pages.
+
+    Prefers ``page_indices.table_of_contents`` (1-based, from the manifest) when
+    available; otherwise scans the first ``scan_pages`` and returns the pages
+    that carry difficulty-glyph entry lines (falling back to pages bearing the
+    "Table of Contents" header for editions rendered without difficulty glyphs).
+    """
+    if page_indices:
+        toc = page_indices.get("table_of_contents") or {}
+        first, last = toc.get("first_page"), toc.get("last_page")
+        if first and last:
+            return list(range(first - 1, last))
+
+    glyph_pages: list[int] = []
+    header_pages: list[int] = []
+    for i in range(min(scan_pages, doc.page_count)):
+        lines = [ln.strip() for ln in doc.load_page(i).get_text().splitlines()]
+        if any(ln[:1] in DIFFICULTY_GLYPHS for ln in lines if ln):
+            glyph_pages.append(i)
+        elif any(_HEADER in ln.lower() for ln in lines if ln):
+            header_pages.append(i)
+    return glyph_pages or header_pages
+
+
+def _clean_entry(text: str, postfixes: list[str]) -> str:
+    """Remove the trailing WIP marker (``*``), any configured postfix, and any
+    trailing emoji/symbol marker — in any order/combination. The leading
+    difficulty glyph is stripped by the caller."""
+    text = text.strip()
+    changed = True
+    while changed:
+        changed = False
+        if text.endswith("*"):
+            text = text[:-1].rstrip()
+            changed = True
+        for p in postfixes:
+            if p and text.endswith(p):
+                text = text[: -len(p)].rstrip()
+                changed = True
+        while text and (
+            unicodedata.category(text[-1]) in _MARKER_CATEGORIES
+            or 0xFE00 <= ord(text[-1]) <= 0xFE0F  # variation selectors
+        ):
+            text = text[:-1].rstrip()
+            changed = True
+        # Drop a short trailing decorative token (a themed postfix glyph that
+        # carries no ASCII letters/digits, e.g. "... - Artist Ἳ"). Length-capped
+        # so genuine non-ASCII title words aren't eaten.
+        head, _, last = text.rpartition(" ")
+        if head and 0 < len(last) <= 2 and not _ASCII_ALNUM.search(last):
+            text = head.rstrip()
+            changed = True
+    return text.strip()
+
+
+def extract_songs_from_lines(lines: list[str], postfixes: list[str]) -> list[str]:
+    """Pure line classifier: turn raw TOC text lines into cleaned song titles.
+
+    A glyph-prefixed line is an entry; a glyph-less "Title - Artist" line is also
+    taken (covers songs with no difficulty assigned and editions rendered without
+    glyphs). Header, page-number and dot-leader lines are ignored. Result is
+    de-duplicated, order-preserving.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for ln in lines:
+        s = ln.strip()
+        if not s:
+            continue
+        if s[0] in DIFFICULTY_GLYPHS:
+            title = _clean_entry(s[1:], postfixes)
+        elif _HEADER not in s.lower() and " - " in s:
+            title = _clean_entry(s, postfixes)
+        else:
+            continue
+        if title and title not in seen:
+            seen.add(title)
+            out.append(title)
+    return out
+
+
+def parse_toc_songs(
+    doc: "fitz.Document",
+    page_indices: Optional[dict[str, Any]] = None,
+    toc_config: Any = None,
+) -> list[str]:
+    """Extract the de-duplicated list of song titles from a PDF's TOC pages.
+
+    Titles are cleaned (no difficulty glyph, WIP marker, or postfix) but remain
+    in the *shortened* form the TOC renders.
+    """
+    config = toc_config or get_settings().toc
+    postfixes = [pf.postfix.strip() for pf in (config.postfixes or []) if pf.postfix]
+
+    lines: list[str] = []
+    for i in find_toc_pages(doc, page_indices):
+        lines.extend(doc.load_page(i).get_text().splitlines())
+    return extract_songs_from_lines(lines, postfixes)


### PR DESCRIPTION
## Closes #381

Reconstructs each edition's song list per publish from the **rendered Table-of-Contents page text**, so the changelog reaches back before the manifest era (~Feb 2026) to the earliest publishes in the bucket. Builds on #377 (`changes.json`) and the canonical-key idea.

### How

- **`generator/toc_parse.py`** — parse song titles from a PDF's TOC pages. Locates pages via manifest `page_indices` or a "Table of Contents" header heuristic; reads glyph-prefixed entries (with a `Title - Artist` fallback). Robustly strips difficulty glyphs, WIP `*`, configured postfixes, **and unknown themed postfix glyphs** — emoji *and* exotic letter markers (a real historical case appended a Greek-letter glyph `ἳ` to ~35 songs, which would otherwise read as 35 fake add/removes).
- **`generator/changelog.py`** — `short_key()` runs any title through the deterministic `generate_short_title`, so a manifest's full `file_names` entry and the shortened TOC title collapse to one comparison key. `diff_keyed()` / `build_timeline()` stitch the manifest era and TOC era into one history, each entry tagged with `source` (`"manifest"` | `"toc-page"`).
- **CLI** `songbook-tools backfill-changelog-from-pdfs --edition <id> --pdfs-dir DIR [--manifests-dir DIR]` — manifests preferred per date (full-name labels); PDFs fill the pre-manifest gap. Existing `backfill-changelog` untouched.

### Validated against the live bucket

- `current` → **19 entries** (2025-10-07 … 2026-06-09); the manifest-era tail matches the existing 8-entry manifest backfill exactly.
- `complete` → **9 entries** (it's the full archive — a stable 272 songs that mostly just grows).
- Parser is stable across all 23 historical `current` PDFs (counts 117–124, all unique) and 24 `complete` PDFs (a clean 272 each).
- The themed-postfix fix collapsed a `complete` boundary diff from a spurious `+35/-35` to a real `+2/-2`.

### Tests

`generator/test_toc_parse.py` (marker/postfix/emoji/letter-glyph stripping, dash fallback, a **real render→parse round-trip**), `generator/test_changelog.py` (`short_key`, `diff_keyed`, cross-era `build_timeline`), CLI e2e on generated PDFs. 74 passing across the touched suites; `ruff` clean.

### Scope note

The bucket's earliest object is **2025-09-27** for every edition — no July/August 2025 files and no alternate naming exist (audited all 289 objects), so GCS publishing began then; nothing earlier can be reconstructed from here. The tool can ingest older PDFs from elsewhere if any surface.

Backfilled `current/changes.json` and `complete/changes.json` are delivered in the session for upload.

https://claude.ai/code/session_014Rx5yvSkbY3H3TF2e45mVi

---
_Generated by [Claude Code](https://claude.ai/code/session_014Rx5yvSkbY3H3TF2e45mVi)_