### PR TITLE
Fix false changelog churn from drifting TOC renders (long titles)

### DIFF
--- a/generator/changelog.py
+++ b/generator/changelog.py
@@ -132,6 +132,58 @@ def short_key(raw: str, max_length: Optional[int] = None) -> str:
     return title.casefold()
 
 
+def canon(raw: str) -> str:
+    """Truncation-insensitive canonical form of a song title for matching.
+
+    Normalizes via :func:`generate_short_title` (drops ``feat.``/version parens
+    the TOC also dropped, *no* truncation), strips trailing decorations
+    (``*``/ellipsis/whitespace), and casefolds. Used as a prefix-matching anchor
+    so a song renders to the same canonical regardless of how a given TOC era
+    truncated or decorated it.
+    """
+    s = generate_short_title(raw or "", max_length=None).strip()
+    changed = True
+    while changed:
+        changed = False
+        for suffix in ("...", "…", "*"):
+            if s.endswith(suffix):
+                s = s[: -len(suffix)].rstrip()
+                changed = True
+    return " ".join(s.split()).casefold()
+
+
+def build_vocabulary(names: list[str]) -> dict[str, str]:
+    """Map ``canon(name) -> name`` for a reference catalogue of full song names."""
+    return {canon(n): n for n in names if canon(n)}
+
+
+def resolve(
+    stem: str, vocabulary: dict[str, str], min_overlap: int = 6
+) -> Optional[str]:
+    """Resolve a (possibly truncated/glued) TOC title to a catalogue full name.
+
+    Matches when ``canon(stem)`` and a vocabulary key are prefix-compatible (one
+    is a prefix of the other) — exactly how the drifting renders relate:
+    truncation makes the TOC string a prefix of the real name; a glued page number
+    makes the real name a prefix of the TOC string. Prefers an exact hit, else the
+    longest overlap (deterministic tiebreak). Returns ``None`` when nothing clears
+    ``min_overlap`` (e.g. a song that predates the catalogue).
+    """
+    key = canon(stem)
+    if not key:
+        return None
+    if key in vocabulary:
+        return vocabulary[key]
+    best: Optional[str] = None
+    best_overlap = -1
+    for vkey, name in vocabulary.items():
+        if vkey.startswith(key) or key.startswith(vkey):
+            overlap = min(len(vkey), len(key))
+            if overlap > best_overlap or (overlap == best_overlap and name < best):
+                best, best_overlap = name, overlap
+    return best if best_overlap >= min_overlap else None
+
+
 def diff_keyed(new: dict[str, str], old: dict[str, str]) -> tuple[list[str], list[str]]:
     """Diff two ``{key: label}`` song maps, returning sorted added/removed labels.
 

--- a/generator/cli/changelog.py
+++ b/generator/cli/changelog.py
@@ -11,8 +11,10 @@ from ..changelog import (
     backfill_history,
     build_entry,
     build_timeline,
+    build_vocabulary,
+    canon,
     empty_history,
-    short_key,
+    resolve,
     update_history,
 )
 from .utils import global_options
@@ -220,13 +222,6 @@ def backfill_changelog(
 )
 @click.option("--edition", required=True, help="Edition id, e.g. 'current'.")
 @click.option(
-    "--max-title-length",
-    type=int,
-    default=None,
-    help="TOC max title length used for canonical matching "
-    "(defaults to the configured Toc.max_toc_entry_length).",
-)
-@click.option(
     "--output",
     type=click.Path(path_type=Path),
     default=Path("changes.json"),
@@ -242,7 +237,6 @@ def backfill_changelog_from_pdfs(
     pdfs_dir: Path,
     manifests_dir: Optional[Path],
     edition: str,
-    max_title_length: Optional[int],
     output: Path,
     max_entries: int,
     **kwargs,
@@ -255,20 +249,14 @@ def backfill_changelog_from_pdfs(
     matched on a canonical shortened-title key so the eras stitch together
     cleanly. Filenames must follow ``ukulele-tuesday-songbook-<edition>-DATE.*``.
     """
-    # Lazy imports: fitz / settings are heavy and only needed here.
+    # Lazy import: fitz is heavy and only needed here.
     import fitz
 
-    from ..common.config import get_settings
     from ..toc_parse import parse_toc_songs
-
-    max_len = (
-        max_title_length
-        if max_title_length is not None
-        else get_settings().toc.max_toc_entry_length
-    )
 
     # date -> publish record; manifests win over PDFs for the same date.
     publishes: dict[str, dict[str, Any]] = {}
+    catalogue: set[str] = set()  # full song names seen across the manifest era
 
     if manifests_dir:
         for path in sorted(manifests_dir.glob("*.manifest.json")):
@@ -278,20 +266,30 @@ def backfill_changelog_from_pdfs(
             except (OSError, ValueError) as e:
                 click.echo(f"Skipping unreadable manifest {path}: {e}", err=True)
                 continue
+            names = manifest.get("content_info", {}).get("file_names") or []
+            # Every manifest's names enrich the resolution vocabulary, even from
+            # other editions (a richer catalogue only improves matching). Pass a
+            # broader --manifests-dir to give rotated-out songs full-name labels.
+            catalogue.update(names)
             ed = (manifest.get("edition") or {}).get("id") or (
                 parsed[0] if parsed else None
             )
             if ed != edition or not parsed:
                 continue
-            names = manifest.get("content_info", {}).get("file_names") or []
             publishes[parsed[1]] = {
                 "date": parsed[1],
                 "generated_at": manifest.get("generated_at", parsed[1]),
                 "source": "manifest",
                 "filename": path.name,
-                "songs": {short_key(n, max_len): n for n in names},
+                "songs": {canon(n): n for n in names},
             }
 
+    # Reference vocabulary of real, full song names. Drifting TOC titles
+    # (truncated / glued page numbers / themed markers) are resolved against it so
+    # the same song collapses to one key regardless of how a TOC era rendered it.
+    vocabulary = build_vocabulary(sorted(catalogue))
+
+    unresolved = 0
     for path in sorted(pdfs_dir.glob("*.pdf")):
         parsed = _parse_edition_date(path.name)
         if not parsed or parsed[0] != edition:
@@ -308,12 +306,20 @@ def backfill_changelog_from_pdfs(
         if not titles:
             click.echo(f"No TOC songs parsed from {path.name}; skipping.", err=True)
             continue
+        songs: dict[str, str] = {}
+        for title in titles:
+            resolved = resolve(title, vocabulary)
+            if resolved is not None:
+                songs[canon(resolved)] = resolved  # clean full-name label
+            else:
+                unresolved += 1
+                songs[canon(title)] = title  # best-effort: predates the catalogue
         publishes[date] = {
             "date": date,
             "generated_at": date,
             "source": "toc-page",
             "filename": path.name,
-            "songs": {short_key(t, max_len): t for t in titles},
+            "songs": songs,
         }
 
     if not publishes:
@@ -327,7 +333,9 @@ def backfill_changelog_from_pdfs(
     click.echo(
         f"✅ Backfilled {len(history['entries'])} changelog entries for "
         f"'{edition}' from {len(publishes)} publishes "
-        f"({n_manifest} manifest, {n_toc} toc-page) -> {output}"
+        f"({n_manifest} manifest, {n_toc} toc-page; "
+        f"{len(vocabulary)} catalogue names, {unresolved} unresolved TOC titles) "
+        f"-> {output}"
     )
 
 

--- a/generator/cli/test_changelog.py
+++ b/generator/cli/test_changelog.py
@@ -176,8 +176,14 @@ def test_backfill_changelog_builds_history(runner, tmp_path):
 
 
 def _write_songbook_pdf(path, names, cover_preface=2):
-    """Render a real TOC and assemble a songbook-like PDF on disk."""
-    files = [File(id=str(i), name=n) for i, n in enumerate(names)]
+    """Render a real TOC and assemble a songbook-like PDF on disk.
+
+    Files carry a 'difficulty' so the TOC renders difficulty glyphs, matching
+    real songbooks (and making long/truncated entries detectable)."""
+    files = [
+        File(id=str(i), name=n, properties={"difficulty": str((i % 5) + 1)})
+        for i, n in enumerate(names)
+    ]
     tp, _ = tocmod.build_table_of_contents(files, 0)
     offset = cover_preface + len(tp)
     tp.close()
@@ -232,3 +238,48 @@ def test_backfill_changelog_from_pdfs_builds_full_history(runner, tmp_path):
     assert entry["source"] == "toc-page"
     assert entry["added"] == ["Hey Jude - The Beatles"]
     assert entry["removed"] == ["Jolene - Dolly Parton"]
+
+
+def test_backfill_from_pdfs_resolves_truncated_toc_title_via_manifest(runner, tmp_path):
+    # A long title is truncated in the historical TOC, but resolves to the full
+    # manifest name -> it must NOT show up as added/removed.
+    long_name = (
+        "This Is An Extremely Long Song Title That Exceeds The Limit - The Verbose Band"
+    )
+    pdfs = tmp_path / "pdfs"
+    pdfs.mkdir()
+    manifests = tmp_path / "manifests"
+    manifests.mkdir()
+    _write_songbook_pdf(
+        pdfs / "ukulele-tuesday-songbook-current-2025-09-27.pdf",
+        [long_name, "Short Song - Artist"],
+    )
+    _write_manifest(
+        manifests / "ukulele-tuesday-songbook-current-2026-02-06.manifest.json",
+        [long_name, "Short Song - Artist", "New Song - X"],
+        generated_at="2026-02-06T00:00:00+00:00",
+        edition_id="current",
+    )
+    out = tmp_path / "changes.json"
+
+    result = runner.invoke(
+        cli,
+        [
+            "backfill-changelog-from-pdfs",
+            "--pdfs-dir",
+            str(pdfs),
+            "--manifests-dir",
+            str(manifests),
+            "--edition",
+            "current",
+            "--output",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    history = json.loads(out.read_text())
+    # Only the genuinely new song changed; the truncated long title resolved.
+    assert len(history["entries"]) == 1
+    entry = history["entries"][0]
+    assert entry["added"] == ["New Song - X"]
+    assert entry["removed"] == []

--- a/generator/test_changelog.py
+++ b/generator/test_changelog.py
@@ -2,10 +2,13 @@ from .changelog import (
     backfill_history,
     build_entry,
     build_timeline,
+    build_vocabulary,
+    canon,
     diff_keyed,
     diff_songs,
     empty_history,
     load_file_names,
+    resolve,
     short_key,
     update_history,
 )
@@ -142,8 +145,77 @@ def test_diff_keyed_uses_keys_but_returns_labels():
     assert removed == ["Song C - Artist"]
 
 
+def test_canon_strips_decorations_and_versions():
+    assert canon("Crocodile Rock (Radio Edit) - Elton John*") == canon(
+        "crocodile rock - elton john"
+    )
+    assert canon("Merry Christmas (I Don't Want to Fight...") == canon(
+        "Merry Christmas (I Don't Want to Fight"
+    )
+
+
+_VOCAB = build_vocabulary(
+    [
+        "Merry Christmas (I Don't Want to Fight Tonight) - Ramones",
+        "Happy Xmas (War is Over) - John Lennon, Yoko Ono",
+        "Time Warp - Little Nell, Patricia Quinn, Richard O'Brien",
+    ]
+)
+
+
+def test_resolve_truncated_title_to_full_catalogue_name():
+    assert (
+        resolve("Merry Christmas (I Don't Want to Fight", _VOCAB)
+        == "Merry Christmas (I Don't Want to Fight Tonight) - Ramones"
+    )
+
+
+def test_resolve_glued_page_number_title():
+    # The clean catalogue name is a prefix of the junk-suffixed TOC string.
+    assert (
+        resolve("Happy Xmas (War is Over) - John Lennon, Yoko Ono104", _VOCAB)
+        == "Happy Xmas (War is Over) - John Lennon, Yoko Ono"
+    )
+
+
+def test_resolve_returns_none_for_non_catalogue_song():
+    assert resolve("Some Forgotten B-Side - Nobody At All", _VOCAB) is None
+
+
 def _pub(date, source, filename, songs):
     return {"date": date, "source": source, "filename": filename, "songs": songs}
+
+
+def test_build_timeline_no_churn_across_drifting_renders():
+    """The same songs rendered full / truncated / truncated-shorter across
+    publishes resolve to one catalogue name each -> no spurious add/remove."""
+
+    def songs(titles):
+        out = {}
+        for t in titles:
+            r = resolve(t, _VOCAB) or t
+            out[canon(r)] = r
+        return out
+
+    full = [
+        "Merry Christmas (I Don't Want to Fight Tonight) - Ramones",
+        "Time Warp - Little Nell, Patricia Quinn, Richard O'Brien",
+    ]
+    truncated = [
+        "Merry Christmas (I Don't Want to Fight Tonight)",
+        "Time Warp - Little Nell, Patricia Quinn, Richard",
+    ]
+    shorter = [
+        "Merry Christmas (I Don't Want to Fight",
+        "Time Warp - Little Nell, Patricia Quinn,",
+    ]
+    publishes = [
+        _pub("2025-09-27", "toc-page", "a.pdf", songs(full)),
+        _pub("2025-10-07", "toc-page", "b.pdf", songs(truncated)),
+        _pub("2025-10-27", "toc-page", "c.pdf", songs(shorter)),
+    ]
+    history = build_timeline(publishes, "complete")
+    assert history["entries"] == []  # stable set despite drifting renders
 
 
 def test_build_timeline_orders_diffs_and_tags_source():

--- a/generator/test_toc_parse.py
+++ b/generator/test_toc_parse.py
@@ -46,6 +46,19 @@ def test_extract_strips_themed_letter_postfix_token():
     assert songs == ["Creep - Radiohead", "Candy - Paolo Nutini"]
 
 
+def test_extract_cuts_marker_with_glued_page_number():
+    # The themed marker can render with the page number glued on (no space).
+    lines = ["◑ Happy Xmas (War is Over) - John Lennon, Yoko Ono Ἴ104"]
+    songs = toc_parse.extract_songs_from_lines(lines, postfixes=[])
+    assert songs == ["Happy Xmas (War is Over) - John Lennon, Yoko Ono"]
+
+
+def test_extract_cuts_truncation_ellipsis_and_marker():
+    lines = ["◔ Merry Christmas (I Don't Want to Fight... Ἴ"]
+    songs = toc_parse.extract_songs_from_lines(lines, postfixes=[])
+    assert songs == ["Merry Christmas (I Don't Want to Fight"]
+
+
 def test_extract_keeps_real_non_ascii_words():
     # Don't eat legitimate accented/foreign title words.
     lines = ["○ Ça plan pour moi - Plastic Bertrand", "○ 99 Luftballons - Nena"]

--- a/generator/toc_parse.py
+++ b/generator/toc_parse.py
@@ -10,7 +10,6 @@ text-extraction ordering quirks.
 
 import logging
 import re
-import unicodedata
 from typing import Any, Optional
 
 import fitz
@@ -22,7 +21,6 @@ from .worker.toc import difficulty_symbol
 # symbols/emoji (So, Sk) and format joiners / variation selectors (Cf). Song
 # titles never legitimately end in these, but historical editions appended
 # themed postfixes we don't have config for, so strip them generically.
-_MARKER_CATEGORIES = {"So", "Sk", "Cf"}
 _ASCII_ALNUM = re.compile(r"[A-Za-z0-9]")
 
 logger = logging.getLogger(__name__)
@@ -30,6 +28,19 @@ logger = logging.getLogger(__name__)
 # Glyphs that prefix every TOC entry (difficulty bins 1-5); see difficulty_symbol.
 DIFFICULTY_GLYPHS = "".join(difficulty_symbol(b) for b in range(1, 6))
 _HEADER = "table of contents"
+_ELLIPSES = ("...", "…")
+
+
+def _is_themed_marker(ch: str) -> bool:
+    """True for the exotic glyphs historical editions append as themed postfixes.
+
+    Covers emoji / supplementary symbols (codepoint >= U+1F000) and the Greek
+    Extended block (U+1F00-U+1FFF), where observed markers like ``Ἴ``/``Ἳ`` live.
+    Deliberately excludes BMP symbols (♥ ★ ♪) and the difficulty glyphs (U+25xx)
+    so legitimate title characters are left alone.
+    """
+    o = ord(ch)
+    return o >= 0x1F000 or 0x1F00 <= o <= 0x1FFF
 
 
 def find_toc_pages(
@@ -62,13 +73,29 @@ def find_toc_pages(
 
 
 def _clean_entry(text: str, postfixes: list[str]) -> str:
-    """Remove the trailing WIP marker (``*``), any configured postfix, and any
-    trailing emoji/symbol marker — in any order/combination. The leading
-    difficulty glyph is stripped by the caller."""
+    """Reduce a raw TOC entry to a clean (shortened) song title.
+
+    The leading difficulty glyph is stripped by the caller. Here we:
+    1. Cut everything from the first themed-marker glyph onward — this removes
+       trailing postfixes like ``Ἴ`` and the page number that can render glued to
+       them (e.g. ``- John Lennon, Yoko Ono Ἴ104`` -> ``- John Lennon, Yoko Ono``).
+    2. Strip trailing truncation ellipses, the WIP ``*`` marker, configured
+       postfixes, and short non-ASCII decorative tokens, in any combination.
+    Note: a page number glued on *without* a marker (e.g. ``- Ramones172``) is
+    left intact here; the caller's prefix matching tolerates that trailing junk.
+    """
     text = text.strip()
+    for i, ch in enumerate(text):
+        if _is_themed_marker(ch):
+            text = text[:i].rstrip()
+            break
     changed = True
     while changed:
         changed = False
+        for suf in _ELLIPSES:
+            if text.endswith(suf):
+                text = text[: -len(suf)].rstrip()
+                changed = True
         if text.endswith("*"):
             text = text[:-1].rstrip()
             changed = True
@@ -76,15 +103,6 @@ def _clean_entry(text: str, postfixes: list[str]) -> str:
             if p and text.endswith(p):
                 text = text[: -len(p)].rstrip()
                 changed = True
-        while text and (
-            unicodedata.category(text[-1]) in _MARKER_CATEGORIES
-            or 0xFE00 <= ord(text[-1]) <= 0xFE0F  # variation selectors
-        ):
-            text = text[:-1].rstrip()
-            changed = True
-        # Drop a short trailing decorative token (a themed postfix glyph that
-        # carries no ASCII letters/digits, e.g. "... - Artist Ἳ"). Length-capped
-        # so genuine non-ASCII title words aren't eaten.
         head, _, last = text.rpartition(" ")
         if head and 0 < len(last) <= 2 and not _ASCII_ALNUM.search(last):
             text = head.rstrip()


### PR DESCRIPTION
## Problem

The TOC-text backfill (#382) produced **false "added/removed" pairs for the same song** on `complete`. Root cause (confirmed on live data): the rendered TOC text for a title **drifts over time**, so a stable song looks like it churned across era boundaries. For `Merry Christmas (I Don't Want to Fight Tonight) - Ramones`:

| Era | Rendered TOC text |
|---|---|
| 2025-09-27 | `…Tonight) - Ramones172` (page number **glued on**) |
| 2025-10-07 | `…to Fight Tonight)...` (**truncated**) |
| 2025-10-27 | `…to Fight... Ἴ` (**truncated shorter** + themed marker) |

Plus `…Yoko Ono Ἴ104` (themed marker `Ἴ` with the page number glued to it). A fixed-length canonical key can't reconcile these.

## Fix

**Key insight:** in every variant, one render is a **prefix** of the other (truncation makes the TOC string a prefix of the real name; glued junk makes the real name a prefix of the TOC string). So resolve each drifting title to the real **song catalogue** via prefix matching — more principled than a fuzzy similarity %.

- **`generator/changelog.py`** — `canon()` (truncation-insensitive normalization), `build_vocabulary()`, and `resolve()` (bidirectional prefix match, longest-overlap, `None` below a min overlap). The catalogue = real song names from the manifest era.
- **`generator/toc_parse.py`** — cut a TOC entry from the first themed-marker glyph onward (handles `Ἴ104` glued page numbers) and strip trailing truncation ellipses. Marker detection is restricted to emoji + the Greek-Extended block, so BMP symbols (♥ ★ ♪) and difficulty glyphs are untouched.
- **CLI `backfill-changelog-from-pdfs`** — builds the vocabulary from all provided manifests (pass a broader `--manifests-dir` to give rotated-out songs full-name labels) and resolves TOC titles through it; dropped the now-unused `--max-title-length`. Resolved TOC entries also get clean **full-name** labels.

## Validation (live bucket)

- **`complete`**: `9` noisy entries → **`6` clean** ones; **0 churn** for the Happy Xmas / Merry Christmas / Time Warp cases; all **272** historical songs resolved to the catalogue (0 unresolved).
- **`current`**: unchanged at 19 entries (its titles are short, so it never had the drift); resolved entries now carry full-name labels.

## Tests

`generator/test_toc_parse.py` — marker+glued-digits and truncation-ellipsis+marker cuts. `generator/test_changelog.py` — `canon`, `resolve` (truncated / glued / non-catalogue), and a `build_timeline` test where one song rendered three ways across publishes yields **zero** churn. `generator/cli/test_changelog.py` — a long title truncated in the TOC resolves to its manifest full name (no churn). 87 passing across touched suites; `ruff` clean.

Updated `current/changes.json` and `complete/changes.json` delivered in-session.

https://claude.ai/code/session_014Rx5yvSkbY3H3TF2e45mVi

---
_Generated by [Claude Code](https://claude.ai/code/session_014Rx5yvSkbY3H3TF2e45mVi)_